### PR TITLE
docs(agents): document Nana and Monteiro Lobato agent classes

### DIFF
--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -2,29 +2,41 @@
 
 ## 📋 Overview
 
-The **Multi-Agent System** is the cognitive core of Cidadão.AI, featuring **17 specialized AI agents** with Brazilian cultural identities. Each agent embodies specific expertise in transparency analysis, from anomaly detection to policy evaluation, working together through sophisticated **coordination patterns** and **self-reflection mechanisms**.
+The **Multi-Agent System** is the cognitive core of Cidadão.AI, featuring **20 specialized AI agents** with Brazilian cultural identities. Each agent embodies specific expertise in transparency analysis, from anomaly detection to policy evaluation, working together through sophisticated **coordination patterns** and **self-reflection mechanisms**.
 
 ## 🏗️ Architecture
 
 ```
 src/agents/
-├── deodoro.py          # Base agent framework & communication protocols  
-├── abaporu.py          # Master agent - investigation orchestration
-├── zumbi.py            # Investigator - anomaly detection specialist
-├── anita.py            # Analyst - pattern analysis expert  
-├── tiradentes.py       # Reporter - natural language generation
-├── ayrton_senna.py     # Semantic router - intelligent query routing
-├── nana.py             # Memory agent - multi-layer memory management (Nanã)
-├── monteiro_lobato.py  # Kids programming educator - Sítio do Picapau Amarelo storytelling
-├── machado.py          # Textual analyst - document processing
-├── bonifacio.py        # Policy analyst - institutional effectiveness
-├── dandara.py          # Social justice - equity monitoring
-├── drummond.py         # Communication - multi-channel messaging
-├── maria_quiteria.py   # Security auditor - system protection
-├── niemeyer.py         # Visualization - data architecture
-├── ceuci.py            # ETL specialist - data processing
-├── obaluaie.py         # Health monitor - wellness tracking
-└── lampiao.py          # Regional analyst - territorial insights
+├── deodoro.py           # Base agent framework & communication protocols
+├── base_kids_agent.py   # Base framework for Education agents (Monteiro Lobato, Tarsila)
+│
+├── abaporu.py           # Master orchestrator - coordinates multi-agent workflows
+├── ayrton_senna.py      # Semantic router - routes queries to the right specialist
+├── nana.py              # Memory agent - multi-layer memory management (Nanã)
+│
+├── zumbi.py             # Investigator - anomaly detection specialist
+├── zumbi_wrapper.py     # Metrics/cache wrapper for Zumbi
+├── anita.py             # Analyst - pattern analysis expert
+├── tiradentes.py        # Reporter - natural language generation
+├── obaluaie.py          # Corruption detector - financial crime signals
+├── oxossi.py            # Fraud hunter - precision fraud detection
+│
+├── machado.py           # Textual analyst - document processing
+├── bonifacio.py         # Policy analyst - institutional effectiveness
+├── dandara.py           # Social justice - equity and inclusion monitoring
+├── maria_quiteria.py    # Security auditor - system protection
+├── oscar_niemeyer.py    # Data aggregator - visualization architecture
+├── lampiao.py           # Regional analyst - territorial insights
+├── ceuci.py             # ETL specialist + ML predictions
+├── ceuci_ml_models.py   # ML models used by Ceuci
+├── drummond.py          # Communication - conversational interface
+├── drummond_simple.py   # Lightweight version of Drummond
+│
+├── santos_dumont.py     # System educator - onboarding for interns/contributors
+├── bo_bardi.py          # Frontend design guide - SSE/component integration
+├── monteiro_lobato.py   # Kids programming educator - Sítio do Picapau Amarelo
+└── tarsila.py           # Kids design educator - colors, shapes, and aesthetics
 ```
 
 ## 🧠 Agent Coordination Patterns
@@ -263,7 +275,7 @@ TextualAnalyst:
 5. Readability and transparency scoring
 ```
 
-### 8. **José Bonifácio** - Policy Analyst (Institutional Architect)
+### 9. **José Bonifácio** - Policy Analyst (Institutional Architect)
 **Cultural Reference**: José Bonifácio - Patriarch of Independence and institutional architect
 
 ```python
@@ -283,7 +295,7 @@ PolicyAnalyst:
 - Social Impact Measurement: Beneficiary outcome tracking
 ```
 
-### 9. **Dandara** - Social Justice Agent (Equity Guardian)
+### 10. **Dandara** - Social Justice Agent (Equity Guardian)
 **Cultural Reference**: Dandara dos Palmares - warrior for social justice and equality
 
 ```python
@@ -301,6 +313,185 @@ SocialJusticeAgent:
 - Atkinson Index: Inequality aversion measurement
 - Theil Index: Decomposable inequality measure
 - Palma Ratio: Top 10% vs. bottom 40% comparison
+```
+
+### 11. **Obaluaiê** - Corruption Detector (Systemic Pattern Analyst)
+**Cultural Reference**: Obaluaiê — Yoruba deity of disease and healing, associated with uncovering hidden afflictions
+
+```python
+# Corruption detection capabilities
+CorruptionDetectorAgent:
+- Cartel detection via Social Network Analysis (Louvain algorithm)
+- Benford's Law analysis: P(d) = log₁₀(1 + 1/d) for bid manipulation
+- Money laundering detection via Graph Neural Networks
+- Nepotism detection through relationship graph analysis
+- Transparency scoring (Transparency Corruption Index — TCI)
+- Deep Neural Network (LSTM) + Isolation Forest for anomaly detection
+
+# Performance metrics
+- Precision: >92% on known corruption schemes
+- Recall:    >88% on suspicious patterns
+- F1-Score:  >0.90 on alert classification
+- False positives: <5% for CRITICAL alerts
+```
+
+**Data Sources:**
+- Portal da Transparência — contracts, bids, expenditures
+- CNJ — related judicial proceedings
+- TCU — audit reports and irregularities
+- COAF — suspicious financial transaction reports
+
+**Severity Levels:** `LOW` / `MEDIUM` / `HIGH` / `CRITICAL`
+
+### 12. **Oxóssi** - Fraud Hunter (Precision Detector)
+
+**Cultural Reference**: Oxóssi — Yoruba deity of the hunt, known for precision and focus
+
+```python
+# Fraud detection capabilities
+OxossiAgent:
+- Bid rigging detection via contract similarity (threshold: 0.85)
+- Price fixing via standard deviation analysis (threshold: 2.5σ)
+- Phantom vendor detection using activity thresholds
+- Invoice fraud detection with confidence scoring
+- Kickback scheme identification through financial forensics
+- Conflict of interest and money laundering pattern analysis
+
+# Fraud severity levels
+- LOW / MEDIUM / HIGH / CRITICAL
+```
+
+**Fraud Types Detected:**
+- `BID_RIGGING` - Coordinated bidding between supposed competitors
+- `PRICE_FIXING` - Statistical price outliers across vendors
+- `PHANTOM_VENDOR` - Shell companies with no real activity
+- `INVOICE_FRAUD` - Anomalous invoice patterns
+- `KICKBACK_SCHEME` - Circular payment detection
+
+### 13. **Drummond** - Communication Agent (Conversational Interface)
+**Cultural Reference**: Carlos Drummond de Andrade — greatest Brazilian poet, known for clarity and wit
+
+```python
+# Communication capabilities
+DrummondAgent:
+- Multi-channel messaging (chat, email, notifications)
+- Conversational interface for citizen queries
+- Natural language response generation
+- Context-aware dialog management
+
+# Variants
+- drummond.py        — Full agent with LLM-backed responses
+- drummond_simple.py — Lightweight rule-based version for low-latency paths
+```
+
+### 14. **Maria Quitéria** - Security Auditor (System Protector)
+**Cultural Reference**: Maria Quitéria de Jesus — first Brazilian woman to serve in the military, symbol of courage
+
+```python
+# Security capabilities
+MariaQuiteria:
+- Input validation and sanitization across all endpoints
+- Permission and role validation
+- Rate limiting enforcement per agent
+- Audit logging of all sensitive agent actions
+- Compliance checking against security frameworks
+```
+
+### 15. **Oscar Niemeyer** - Data Aggregator (Visualization Architect)
+**Cultural Reference**: Oscar Niemeyer (1907–2012) — architect of Brasília, master of bold structural design
+
+```python
+# Data aggregation capabilities
+OscarNiemeyerAgent:
+- Aggregates results from multiple agents into unified structures
+- Builds visualization-ready data schemas
+- Coordinates data architecture for dashboard consumption
+```
+
+### 16. **Lampião** - Regional Analyst (Territorial Specialist)
+**Cultural Reference**: Virgulino Ferreira da Silva (Lampião) — legendary cangaceiro, deep roots in the Brazilian Northeast
+
+```python
+# Regional analysis capabilities
+LampiaoAgent:
+- State and municipal-level spending analysis
+- Regional inequality detection across Brazilian territories
+- Cross-region pattern comparison
+- Focus on underserved and remote municipalities
+```
+
+### 17. **Ceuci** - ETL Specialist (Data Engineer + ML)
+**Cultural Reference**: Ceuci — indigenous deity of fertility and abundance in Tupi mythology
+
+```python
+# ETL and ML capabilities
+CeuciAgent:
+- Data extraction, transformation, and loading pipelines
+- ML-based predictions (via ceuci_ml_models.py)
+- Data quality validation and anomaly pre-processing
+- Feeds cleaned datasets to investigator and analyst agents
+```
+
+### 18. **Santos-Dumont** - System Educator (Onboarding Guide)
+**Cultural Reference**: Alberto Santos-Dumont (1873–1932) — inventor of the 14-Bis, pioneer who shared his inventions freely
+
+```python
+# Educational capabilities
+EducatorAgent:
+- System architecture walkthrough for interns and new contributors
+- Agent-by-agent capability explanations
+- API structure overview (323+ endpoints, 39 routes)
+- Contribution guide: commits, tests, PR workflow
+- Troubleshooting common development issues
+
+# Teaching philosophy
+"O que eu fiz, qualquer um pode fazer" — democratising knowledge
+```
+
+**Learning Topics:**
+- `SYSTEM_OVERVIEW` - Multi-agent architecture and flows
+- `AGENT_ARCHITECTURE` - BaseAgent patterns and lifecycle
+- `API_STRUCTURE` - Endpoints, middleware, auth, SSE
+- `CONTRIBUTION_GUIDE` - First commit to merged PR
+- `FIRST_MISSION` - Guided first task for new interns
+
+### 19. **Lina Bo Bardi** - Frontend Design Guide (Integration Architect)
+**Cultural Reference**: Lina Bo Bardi (1914–1992) — Italian-Brazilian architect of MASP and SESC Pompeia, champion of accessible design
+
+```python
+# Frontend guidance capabilities
+FrontendDesignerAgent:
+- SSE integration guide for /api/v1/chat/stream
+- React/Vue/Angular component structure patterns
+- Accessibility (WCAG, VLibras, semantic HTML)
+- Responsive design and mobile-first patterns
+- Error handling and reconnection strategies
+
+# Design philosophy
+"Design deve ser acessível a TODOS" — functionality over elitism
+```
+
+**Frontend Topics:**
+- `SSE_INTEGRATION` - Consuming streaming chat events
+- `COMPONENT_STRUCTURE` - Reusable component patterns
+- `ACCESSIBILITY` - WCAG compliance and VLibras
+- `RESPONSIVE_DESIGN` - Mobile-first layouts
+
+### 20. **Tarsila do Amaral** - Kids Design Educator
+**Cultural Reference**: Tarsila do Amaral (1886–1973) — painter of Abaporu and icon of Brazilian Modernism
+
+```python
+# Kids design teaching capabilities
+KidsDesignAgent (BaseKidsAgent):
+- Teaches colors, shapes, contrast, harmony, and balance to children
+- Uses her own paintings as visual metaphors (Abaporu, Operários)
+- Tropical color palette references from Brazilian nature
+- Safe content filtering inherited from BaseKidsAgent
+
+# Teaching metaphors
+- Warm colors → "energia do sol brasileiro"
+- Cool colors → "tranquilidade da água"
+- Abaporu → oversized shapes conveying strength
 ```
 
 ## 🔄 Agent Lifecycle & State Management

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -14,7 +14,8 @@ src/agents/
 ├── anita.py            # Analyst - pattern analysis expert  
 ├── tiradentes.py       # Reporter - natural language generation
 ├── ayrton_senna.py     # Semantic router - intelligent query routing
-├── nana.py             # Memory agent - multi-layer memory management
+├── nana.py             # Memory agent - multi-layer memory management (Nanã)
+├── monteiro_lobato.py  # Kids programming educator - Sítio do Picapau Amarelo storytelling
 ├── machado.py          # Textual analyst - document processing
 ├── bonifacio.py        # Policy analyst - institutional effectiveness
 ├── dandara.py          # Social justice - equity monitoring
@@ -219,7 +220,29 @@ Conversational: Dialog context and user preferences
 - `maintain_conversation()` - Preserve dialog context
 - `consolidate_memory()` - Long-term memory formation
 
-### 7. **Machado de Assis** - Textual Analyst (Document Master)
+### 7. **Monteiro Lobato** - Kids Programming Educator
+
+**Cultural Reference**: José Bento Renato Monteiro Lobato (1882–1948) — father of Brazilian children's literature and creator of the Sítio do Picapau Amarelo universe.
+
+```python
+# Teaching capabilities
+KidsProgrammingAgent:
+- Explains programming concepts through Sítio do Picapau Amarelo storytelling
+- Variables as "Emília's magic boxes", loops as "Saci jumping repeatedly"
+- Functions as "Tia Nastacia's recipes", conditionals as "Pedrinho's decisions"
+- Safe content filtering via BaseKidsAgent (BLOCKED_TOPICS, topic allowlist)
+- Fallback responses for offline/error scenarios
+
+# Routing
+- Invoked by Ayrton Senna for children's education queries
+- Responses capped at 150 words, always in simple language
+```
+
+**Key Methods:**
+- `_get_fallback_response()` - Returns pre-written explanations for common concepts
+- `_get_safe_redirect_response()` - Redirects off-topic or unsafe content
+
+### 8. **Machado de Assis** - Textual Analyst (Document Master)
 **Cultural Reference**: Machado de Assis - greatest Brazilian writer and literary genius
 
 ```python

--- a/src/agents/monteiro_lobato.py
+++ b/src/agents/monteiro_lobato.py
@@ -219,31 +219,38 @@ LEMBRE-SE: Voce e um educador GENTIL e PACIENTE. Criancas podem errar e pergunta
 
 
 class KidsProgrammingAgent(BaseKidsAgent):
-    """
-    Monteiro Lobato - Educador de Programacao para Criancas
+    """Monteiro Lobato — Kids Programming Education Agent for Cidadão.AI.
 
-    MISSAO:
-    Ensinar conceitos de programacao para criancas usando linguagem natural,
-    historias divertidas e referencias ao Sitio do Picapau Amarelo.
+    Teaches programming concepts to children (ages 6-12) through storytelling,
+    using characters from the Sítio do Picapau Amarelo as teaching metaphors
+    (e.g. variables as "Emília's magic boxes", loops as "Saci jumping repeatedly").
 
-    SOBRE MONTEIRO LOBATO:
-    - Jose Bento Renato Monteiro Lobato (1882-1948)
-    - Considerado o pai da literatura infantil brasileira
-    - Criador do Sitio do Picapau Amarelo e personagens iconicos
-    - Revolucionou a forma de falar com criancas sobre temas complexos
-    - Misturava fantasia com educacao de forma natural
+    Routed by Ayrton Senna when a query is classified as a children's education
+    request. All responses are capped at 150 words and use simple language.
 
-    FILOSOFIA:
-    - "Um pais se faz com homens e livros" - educacao como base
-    - Criancas sao inteligentes e merecem respeito intelectual
-    - Aprender deve ser divertido como uma aventura no Sitio
-    - Usar fantasia para explicar conceitos reais
+    About Monteiro Lobato:
+        José Bento Renato Monteiro Lobato (1882–1948) is considered the father
+        of Brazilian children's literature and creator of the Sítio do Picapau
+        Amarelo universe. He revolutionised how complex subjects are explained
+        to children by blending fantasy with education — the same philosophy
+        applied here. As he wrote: "Um país se faz com homens e livros."
 
-    Inherits safety features from BaseKidsAgent:
-    - BLOCKED_TOPICS filtering
-    - is_content_safe() method
-    - is_topic_allowed() method
-    - Safe redirect behavior
+    Philosophy:
+        - Children are intelligent and deserve intellectual respect.
+        - Learning should feel like an adventure at the Sítio.
+        - Fantasy is a vehicle for explaining real concepts.
+
+    Safety:
+        Inherits topic filtering and content-safety checks from ``BaseKidsAgent``
+        (``BLOCKED_TOPICS``, ``is_content_safe()``, ``is_topic_allowed()``).
+        Off-topic messages are redirected, never answered.
+
+    Example:
+        Input:  "O que é uma variável?"
+        Output: Explanation using Emília's colored boxes metaphor, ≤150 words.
+
+        Input:  "Como funciona um loop?"
+        Output: Explanation using Saci jumping repeatedly, ≤150 words.
     """
 
     # Domain-specific allowed topics (inherited from BaseKidsAgent)
@@ -277,7 +284,16 @@ class KidsProgrammingAgent(BaseKidsAgent):
         self.logger.info(f"{self.name} agent shutting down - Ate a proxima aventura!")
 
     def _get_safe_redirect_response(self) -> str:
-        """Get a safe redirect response when content is not appropriate."""
+        """Return a fixed redirect message for off-topic or unsafe content.
+
+        Called by ``BaseKidsAgent`` when ``is_content_safe()`` or
+        ``is_topic_allowed()`` returns False. Gently steers the child back
+        to programming topics without explaining why the question was blocked.
+
+        Returns:
+            A hardcoded Portuguese-language redirect string offering three
+            programming topics the child can choose from.
+        """
         return """Opa, amiguinho! Essa pergunta e bem interessante, mas sabe o que seria mais legal?
 
 Vamos falar sobre programacao! Aqui no Sitio do Picapau Amarelo, a Emilia e eu adoramos criar coisas incriveis com codigo!

--- a/src/agents/nana.py
+++ b/src/agents/nana.py
@@ -67,11 +67,22 @@ class ConversationMemory(MemoryEntry):
 
 
 class ContextMemoryAgent(BaseAgent):
-    """
-    Agent responsible for managing different types of memory:
-    - Episodic: Specific investigations and their results
-    - Semantic: General knowledge about patterns and anomalies
-    - Conversational: Context from ongoing conversations
+    """Nanã — Context Memory Agent for Cidadão.AI.
+
+    Manages three memory layers to preserve state across interactions:
+    - Episodic: specific investigation results, stored in Redis + ChromaDB
+    - Semantic: general knowledge about patterns and anomalies, stored in ChromaDB
+    - Conversational: ongoing dialog context, stored in Redis with a 24h TTL
+
+    Invoked automatically by Abaporu after each investigation to persist results,
+    and consulted by Ayrton Senna when routing queries that require historical context.
+
+    Example:
+        Input:  action="store_episodic", payload={"memory_entry": {...}}
+        Output: {"status": "stored", "memory_id": "mem_inv_123_..."}
+
+        Input:  action="get_relevant_context", payload={"query": "emergency contract"}
+        Output: {"episodic": [...], "semantic": [...], "conversation": [...]}
     """
 
     def __init__(
@@ -309,7 +320,20 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Store episodic memory."""
+        """Store an episodic memory entry in Redis and the vector store.
+
+        Args:
+            payload: Must contain a ``memory_entry`` dict with at least
+                ``investigation_id``, ``query``, and ``result`` fields.
+            context: Current agent context used for logging.
+
+        Returns:
+            A dict with ``status`` ("stored") and ``memory_id``.
+
+        Raises:
+            MemoryStorageError: If ``memory_entry`` is missing or the
+                underlying storage operations fail.
+        """
         try:
             memory_entry = payload.get("memory_entry")
             if not memory_entry:
@@ -372,7 +396,22 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Retrieve episodic memories."""
+        """Retrieve episodic memories matching a query via semantic search.
+
+        If ``query`` is omitted, returns the most recent memories up to
+        ``limit``. Otherwise performs a vector similarity search in ChromaDB,
+        then fetches the full memory data from Redis.
+
+        Args:
+            payload: May contain ``query`` (str) and ``limit`` (int, default 5).
+            context: Current agent context used for logging.
+
+        Returns:
+            A dict with a ``memories`` list of episodic memory dicts.
+
+        Raises:
+            MemoryRetrievalError: If the vector store or Redis lookup fails.
+        """
         try:
             query = payload.get("query", "")
             limit = payload.get("limit", 5)
@@ -415,7 +454,25 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Store semantic memory."""
+        """Store a semantic memory entry representing a general knowledge concept.
+
+        Semantic memories use a 2× longer TTL than episodic ones since they
+        encode durable knowledge (patterns, anomaly signatures) rather than
+        one-off events.
+
+        Args:
+            payload: Must contain ``concept`` (str) and ``content`` (dict or str).
+                Optional fields: ``relationships`` (list[str]), ``evidence``
+                (list[str]), and ``confidence`` (float, default 0.5).
+            context: Current agent context used for logging.
+
+        Returns:
+            A dict with ``status`` ("stored") and ``memory_id``.
+
+        Raises:
+            MemoryStorageError: If ``concept`` or ``content`` is missing, or if
+                storage operations fail.
+        """
         try:
             concept = payload.get("concept", "")
             content = payload.get("content", {})
@@ -478,7 +535,18 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Retrieve semantic memories."""
+        """Retrieve semantic memories matching a query via vector similarity search.
+
+        Args:
+            payload: May contain ``query`` (str) and ``limit`` (int, default 5).
+            context: Current agent context used for logging.
+
+        Returns:
+            A dict with a ``concepts`` list of semantic memory dicts.
+
+        Raises:
+            MemoryRetrievalError: If the vector store or Redis lookup fails.
+        """
         try:
             query = payload.get("query", "")
             limit = payload.get("limit", 5)
@@ -514,7 +582,25 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Store conversation memory."""
+        """Store a single conversation turn in Redis with a 24-hour TTL.
+
+        Automatically increments the turn counter for the conversation and
+        trims older turns if the conversation exceeds ``max_conversation_turns``.
+
+        Args:
+            payload: Must contain ``message`` (str) and optionally
+                ``conversation_id`` (str, falls back to ``context.session_id``),
+                ``speaker`` (str, default "user"), and ``intent`` (str).
+            context: Current agent context; ``session_id`` is used as the
+                fallback conversation ID.
+
+        Returns:
+            A dict with ``status`` ("stored") and ``turn_number`` (int).
+
+        Raises:
+            MemoryStorageError: If ``conversation_id`` or ``message`` is missing,
+                or if Redis operations fail.
+        """
         try:
             conversation_id = payload.get("conversation_id", context.session_id)
             message = payload.get("message", "")
@@ -572,7 +658,21 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Get conversation context."""
+        """Retrieve recent turns from a conversation, ordered chronologically.
+
+        Args:
+            payload: May contain ``conversation_id`` (str, falls back to
+                ``context.session_id``) and ``limit`` (int, default 10).
+            context: Current agent context; ``session_id`` is used as the
+                fallback conversation ID.
+
+        Returns:
+            A dict with a ``conversation`` list of turn dicts in ascending
+            turn-number order.
+
+        Raises:
+            MemoryRetrievalError: If Redis key scanning or data retrieval fails.
+        """
         try:
             conversation_id = payload.get("conversation_id", context.session_id)
             limit = payload.get("limit", 10)
@@ -612,7 +712,19 @@ class ContextMemoryAgent(BaseAgent):
         payload: dict[str, Any],
         context: AgentContext,
     ) -> dict[str, Any]:
-        """Get all relevant context for a query."""
+        """Dispatch to ``get_relevant_context`` from a message payload.
+
+        Thin adapter between the action-dispatch loop in ``process()`` and the
+        public ``get_relevant_context`` method.
+
+        Args:
+            payload: May contain ``query`` (str) and ``limit`` (int, default 5).
+            context: Current agent context forwarded to sub-retrievals.
+
+        Returns:
+            Combined context dict with ``episodic``, ``semantic``, and
+            ``conversation`` keys plus the original ``query`` and a timestamp.
+        """
         return await self.get_relevant_context(
             payload.get("query", ""), context, payload.get("limit", 5)
         )
@@ -921,7 +1033,18 @@ class ContextMemoryAgent(BaseAgent):
         return consolidated
 
     def _calculate_importance(self, investigation_result: Any) -> MemoryImportance:
-        """Calculate importance of an investigation result."""
+        """Derive a ``MemoryImportance`` level from an investigation result.
+
+        Uses confidence score and findings count as a two-dimensional heuristic:
+        high confidence + many findings → CRITICAL, low confidence → LOW.
+
+        Args:
+            investigation_result: Any object with ``confidence_score`` (float)
+                and ``findings`` (list) attributes.
+
+        Returns:
+            A ``MemoryImportance`` enum value (CRITICAL, HIGH, MEDIUM, or LOW).
+        """
         confidence = getattr(investigation_result, "confidence_score", 0.0)
         findings_count = len(getattr(investigation_result, "findings", []))
 
@@ -934,8 +1057,15 @@ class ContextMemoryAgent(BaseAgent):
         return MemoryImportance.LOW
 
     def _extract_tags(self, text: str) -> list[str]:
-        """Extract tags from text for better organization."""
-        # Simple tag extraction - could be enhanced with NLP
+        """Extract domain-relevant tags from text using keyword matching.
+
+        Args:
+            text: Raw text to scan (query, concept, or message).
+
+        Returns:
+            A list of matched keywords from the predefined domain vocabulary.
+        """
+        # Simple keyword match — could be enhanced with NLP
         keywords = [
             "contrato",
             "licitação",
@@ -953,7 +1083,7 @@ class ContextMemoryAgent(BaseAgent):
         return [keyword for keyword in keywords if keyword in text_lower]
 
     async def _manage_memory_size(self) -> None:
-        """Manage memory size by removing old/unimportant memories."""
+        """Evict oldest episodic memories when the store exceeds ``max_episodic_memories``."""
         # Get count of episodic memories
         pattern = f"{self.episodic_key}:*"
         keys = await self.redis_client.keys(pattern)
@@ -972,7 +1102,7 @@ class ContextMemoryAgent(BaseAgent):
             )
 
     async def _manage_conversation_size(self, conversation_id: str) -> None:
-        """Manage conversation memory size."""
+        """Evict oldest turns when a conversation exceeds ``max_conversation_turns``."""
         pattern = f"{self.conversation_key}:{conversation_id}:*"
         keys = await self.redis_client.keys(pattern)
 
@@ -991,7 +1121,14 @@ class ContextMemoryAgent(BaseAgent):
             )
 
     async def _get_recent_memories(self, limit: int) -> list[dict[str, Any]]:
-        """Get recent episodic memories."""
+        """Return the most recent episodic memories sorted by timestamp descending.
+
+        Args:
+            limit: Maximum number of memories to return.
+
+        Returns:
+            A list of episodic memory dicts, newest first, capped at ``limit``.
+        """
         pattern = f"{self.episodic_key}:*"
         keys = await self.redis_client.keys(pattern)
 


### PR DESCRIPTION
# O que foi feito

  - Adicionei docstrings no formato Google em nana.py — classe ContextMemoryAgent e todos os métodos privados com Args, Returns e Raises
  - Adicionei docstrings no formato Google em monteiro_lobato.py — classe KidsProgrammingAgent
  _get_safe_redirect_response documentado
  - Atualizei src/agents/README.md: contagem corrigida para 20 agentes, file tree reconstruído com todos os agentes e arquivos de suporte, seções de perfil adicionadas para os 11 agentes que estavam faltando, numeração sequencial corrigida

 # Observações
  - Vários agentes estavam faltando no README (Oxóssi, Bo Bardi, Santos Dumont, Tarsila, Obaluaiê) — adicionei todos aproveitando o escopo da issue