### PR TITLE
style: apply black formatting (no logic changes)

### DIFF
--- a/src/agents/tiradentes.py
+++ b/src/agents/tiradentes.py
@@ -786,8 +786,7 @@ class ReporterAgent(BaseAgent):
         html_parts = []
 
         # HTML header
-        html_parts.append(
-            """
+        html_parts.append("""
         <!DOCTYPE html>
         <html lang="pt-BR">
         <head>
@@ -805,22 +804,19 @@ class ReporterAgent(BaseAgent):
             </style>
         </head>
         <body>
-        """
-        )
+        """)
 
         # Report content
         html_parts.append(
             f"<h1>Relatório: {request.report_type.value.replace('_', ' ').title()}</h1>"
         )
-        html_parts.append(
-            f"""
+        html_parts.append(f"""
         <div class="metadata">
             <strong>Data:</strong> {datetime.now(UTC).strftime('%d/%m/%Y %H:%M')}<br>
             <strong>ID da Investigação:</strong> {context.investigation_id}<br>
             <strong>Público-alvo:</strong> {request.target_audience}
         </div>
-        """
-        )
+        """)
 
         # Render sections
         for section in sorted(sections, key=lambda s: s.importance, reverse=True):
@@ -835,14 +831,12 @@ class ReporterAgent(BaseAgent):
             html_parts.append("</div>")
 
         # HTML footer
-        html_parts.append(
-            """
+        html_parts.append("""
         <hr>
         <p><em>Relatório gerado automaticamente pelo sistema Cidadão.AI</em></p>
         </body>
         </html>
-        """
-        )
+        """)
 
         return "\n".join(html_parts)
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -118,7 +118,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         from alembic.config import Config
 
         # Use absolute path to find alembic.ini regardless of CWD
-        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        base_dir = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
         alembic_ini = os.path.join(base_dir, "alembic.ini")
 
         if os.path.exists(alembic_ini):

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -76,7 +76,10 @@ def get_current_optional_user(request: Request) -> dict[str, Any] | None:
                 return None
             except jwt.PyJWTError as e:
                 _dep_logger.warning(
-                    "jwt_decode_failed", source=source, error=str(e), path=request.url.path
+                    "jwt_decode_failed",
+                    source=source,
+                    error=str(e),
+                    path=request.url.path,
                 )
                 continue
 

--- a/src/api/middleware/authentication.py
+++ b/src/api/middleware/authentication.py
@@ -154,9 +154,7 @@ class AuthenticationMiddleware:
                 # Check expiration
                 exp = payload.get("exp")
                 if exp and datetime.now(UTC).timestamp() > exp:
-                    raise HTTPException(
-                        status_code=401, detail="Token has expired"
-                    )
+                    raise HTTPException(status_code=401, detail="Token has expired")
 
                 # Store user info in request state
                 request.state.user_id = payload.get("sub")

--- a/src/api/middleware/cors_enhanced.py
+++ b/src/api/middleware/cors_enhanced.py
@@ -139,9 +139,9 @@ class EnhancedCORSMiddleware(BaseHTTPMiddleware):
         requested_method = request.headers.get("Access-Control-Request-Method")
         requested_headers = [
             h.strip()
-            for h in request.headers.get(
-                "Access-Control-Request-Headers", ""
-            ).split(",")
+            for h in request.headers.get("Access-Control-Request-Headers", "").split(
+                ","
+            )
             if h.strip()
         ]
 

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -1666,7 +1666,11 @@ async def stream_message(
             return StreamingResponse(
                 edge_case_generator(),
                 media_type="text/event-stream",
-                headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
             )
 
     async def generate():
@@ -1939,7 +1943,9 @@ async def stream_message(
                     payload = json_utils.loads(event_str[6:].strip())
                     if payload.get("type") == "chunk" and payload.get("content"):
                         chunks.append(payload["content"])
-                    elif payload.get("type") == "agent_selected" and payload.get("agent_id"):
+                    elif payload.get("type") == "agent_selected" and payload.get(
+                        "agent_id"
+                    ):
                         agent_id_captured = payload["agent_id"]
                 except Exception:
                     pass
@@ -2022,7 +2028,12 @@ async def list_user_sessions(
         offset=offset,
     )
 
-    return {"sessions": sessions, "count": len(sessions), "limit": limit, "offset": offset}
+    return {
+        "sessions": sessions,
+        "count": len(sessions),
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @router.get("/sessions/{session_id}")

--- a/src/api/routes/debug.py
+++ b/src/api/routes/debug.py
@@ -313,8 +313,7 @@ async def list_all_investigations() -> dict[str, Any]:
         pool = await get_db_pool()
 
         async with pool.acquire() as conn:
-            rows = await conn.fetch(
-                """
+            rows = await conn.fetch("""
                 SELECT
                     id,
                     user_id,
@@ -330,8 +329,7 @@ async def list_all_investigations() -> dict[str, Any]:
                 FROM investigations
                 ORDER BY created_at DESC
                 LIMIT 10
-            """
-            )
+            """)
 
             for row in rows:
                 result["investigations"].append(
@@ -477,13 +475,11 @@ async def check_database_constraints() -> dict[str, Any]:
         # Check constraints on investigations table
         try:
             async with pool.acquire() as conn:
-                rows = await conn.fetch(
-                    """
+                rows = await conn.fetch("""
                     SELECT conname, pg_get_constraintdef(oid) as definition
                     FROM pg_constraint
                     WHERE conrelid = 'investigations'::regclass;
-                    """
-                )
+                    """)
                 result["constraints"] = [
                     {"name": row["conname"], "definition": row["definition"]}
                     for row in rows
@@ -596,35 +592,29 @@ async def fix_database_schema() -> dict[str, Any]:
         try:
             async with pool.acquire() as conn:
                 # First, find the constraint name
-                constraint_row = await conn.fetchrow(
-                    """
+                constraint_row = await conn.fetchrow("""
                     SELECT conname
                     FROM pg_constraint
                     WHERE conrelid = 'investigations'::regclass
                     AND contype = 'c'
                     AND pg_get_constraintdef(oid) LIKE '%status%';
-                    """
-                )
+                    """)
 
                 if constraint_row:
                     constraint_name = constraint_row["conname"]
 
                     # Drop the old constraint
-                    await conn.execute(
-                        f"""
+                    await conn.execute(f"""
                         ALTER TABLE investigations
                         DROP CONSTRAINT {constraint_name};
-                        """
-                    )
+                        """)
 
                     # Create new constraint with 'running' status
-                    await conn.execute(
-                        """
+                    await conn.execute("""
                         ALTER TABLE investigations
                         ADD CONSTRAINT investigations_status_check
                         CHECK (status IN ('pending', 'running', 'completed', 'failed'));
-                        """
-                    )
+                        """)
 
                     result["fixes_applied"].append(
                         {
@@ -649,15 +639,13 @@ async def fix_database_schema() -> dict[str, Any]:
         # Verify the fix
         try:
             async with pool.acquire() as conn:
-                row = await conn.fetchrow(
-                    """
+                row = await conn.fetchrow("""
                     SELECT conname, pg_get_constraintdef(oid) as definition
                     FROM pg_constraint
                     WHERE conrelid = 'investigations'::regclass
                     AND contype = 'c'
                     AND pg_get_constraintdef(oid) LIKE '%status%';
-                """
-                )
+                """)
                 if row:
                     result["verification"] = {
                         "constraint_name": row["conname"],
@@ -968,16 +956,12 @@ async def fix_stuck_investigations() -> dict[str, Any]:
 
         async with engine.begin() as conn:
             # First, get stuck investigations
-            stuck_result = await conn.execute(
-                text(
-                    """
+            stuck_result = await conn.execute(text("""
                     SELECT id, query, created_at
                     FROM investigations
                     WHERE status = 'running'
                     AND created_at < NOW() - INTERVAL '1 hour'
-                    """
-                )
-            )
+                    """))
             stuck_rows = stuck_result.fetchall()
 
             for row in stuck_rows:
@@ -990,9 +974,7 @@ async def fix_stuck_investigations() -> dict[str, Any]:
                 )
 
             # Update stuck investigations
-            update_result = await conn.execute(
-                text(
-                    """
+            update_result = await conn.execute(text("""
                     UPDATE investigations
                     SET status = 'failed',
                         error_message = 'Investigation timed out (stuck in running state for >1 hour)',
@@ -1000,9 +982,7 @@ async def fix_stuck_investigations() -> dict[str, Any]:
                     WHERE status = 'running'
                     AND created_at < NOW() - INTERVAL '1 hour'
                     RETURNING id
-                    """
-                )
-            )
+                    """))
 
             result["fixed_count"] = update_result.rowcount
 

--- a/src/infrastructure/health/dependency_checker.py
+++ b/src/infrastructure/health/dependency_checker.py
@@ -213,17 +213,13 @@ class DatabaseHealthCheck(BaseHealthCheck):
                 raise Exception("Database query returned unexpected result")
 
             # Get database stats
-            stats_result = await session.execute(
-                text(
-                    """
+            stats_result = await session.execute(text("""
                 SELECT
                     count(*) as active_connections,
                     (SELECT setting FROM pg_settings WHERE name = 'max_connections') as max_connections
                 FROM pg_stat_activity
                 WHERE state = 'active'
-            """
-                )
-            )
+            """))
 
             stats = stats_result.fetchone()
 

--- a/src/infrastructure/orchestrator.py
+++ b/src/infrastructure/orchestrator.py
@@ -308,7 +308,9 @@ class CidadaoAIOrchestrator:
                     return True
 
                 except Exception as e:
-                    logger.warning(f"⚠️ Tentativa {attempt + 1} falhou para {name}: {e}")
+                    logger.warning(
+                        f"⚠️ Tentativa {attempt + 1} falhou para {name}: {e}"
+                    )
 
                     if attempt < self.config.max_retries - 1:
                         await asyncio.sleep(self.config.retry_delay)

--- a/src/infrastructure/query_analyzer.py
+++ b/src/infrastructure/query_analyzer.py
@@ -81,8 +81,7 @@ class QueryAnalyzer:
                 return []
 
             # Get slow queries
-            query = text(
-                """
+            query = text("""
                 SELECT
                     query,
                     calls,
@@ -100,8 +99,7 @@ class QueryAnalyzer:
                     AND query NOT LIKE 'BEGIN%'
                 ORDER BY mean_exec_time DESC
                 LIMIT :limit
-            """
-            )
+            """)
 
             result = await session.execute(
                 query, {"threshold": self.slow_query_threshold_ms, "limit": limit}
@@ -139,8 +137,7 @@ class QueryAnalyzer:
 
         try:
             # Find tables with sequential scans
-            query = text(
-                """
+            query = text("""
                 SELECT
                     schemaname,
                     tablename,
@@ -153,8 +150,7 @@ class QueryAnalyzer:
                     AND seq_tup_read > 100000
                     AND schemaname = 'public'
                 ORDER BY seq_tup_read DESC
-            """
-            )
+            """)
 
             result = await session.execute(query)
 
@@ -175,8 +171,7 @@ class QueryAnalyzer:
                         )
 
             # Check for foreign keys without indexes
-            fk_query = text(
-                """
+            fk_query = text("""
                 SELECT
                     tc.table_name,
                     kcu.column_name
@@ -192,8 +187,7 @@ class QueryAnalyzer:
                         WHERE tablename = tc.table_name
                             AND indexdef LIKE '%' || kcu.column_name || '%'
                     )
-            """
-            )
+            """)
 
             fk_result = await session.execute(fk_query)
 
@@ -287,8 +281,7 @@ class QueryAnalyzer:
     ) -> dict[str, Any]:
         """Get statistics for a specific table."""
         try:
-            stats_query = text(
-                """
+            stats_query = text("""
                 SELECT
                     n_live_tup as row_count,
                     n_dead_tup as dead_rows,
@@ -298,8 +291,7 @@ class QueryAnalyzer:
                     last_autoanalyze
                 FROM pg_stat_user_tables
                 WHERE tablename = :table
-            """
-            )
+            """)
 
             result = await session.execute(stats_query, {"table": table})
             row = result.first()

--- a/src/infrastructure/queue/tasks/auto_investigation_tasks.py
+++ b/src/infrastructure/queue/tasks/auto_investigation_tasks.py
@@ -332,8 +332,7 @@ async def _cleanup_stuck_investigations_async(
         async with engine.begin() as conn:
             # Find and update stuck investigations using parameterized query
             update_result = await conn.execute(
-                text(
-                    """
+                text("""
                     UPDATE investigations
                     SET status = 'failed',
                         error_message = :error_message,
@@ -341,8 +340,7 @@ async def _cleanup_stuck_investigations_async(
                     WHERE status = 'running'
                     AND created_at < :threshold_time
                     RETURNING id, query, created_at
-                    """
-                ),
+                    """),
                 {"error_message": error_msg, "threshold_time": threshold_time},
             )
 
@@ -431,27 +429,19 @@ async def _generate_metrics_report_async() -> dict[str, Any]:
 
         async with engine.begin() as conn:
             # Total investigations in last 24h
-            total_result = await conn.execute(
-                text(
-                    """
+            total_result = await conn.execute(text("""
                     SELECT COUNT(*) FROM investigations
                     WHERE created_at > NOW() - INTERVAL '24 hours'
-                    """
-                )
-            )
+                    """))
             report["total_investigations"] = total_result.scalar() or 0
 
             # By status
-            status_result = await conn.execute(
-                text(
-                    """
+            status_result = await conn.execute(text("""
                     SELECT status, COUNT(*) as count
                     FROM investigations
                     WHERE created_at > NOW() - INTERVAL '24 hours'
                     GROUP BY status
-                    """
-                )
-            )
+                    """))
             report["by_status"] = {row[0]: row[1] for row in status_result.fetchall()}
 
             # Success rate
@@ -460,32 +450,24 @@ async def _generate_metrics_report_async() -> dict[str, Any]:
             report["success_rate"] = completed / total if total > 0 else 0
 
             # Average processing time for completed investigations
-            time_result = await conn.execute(
-                text(
-                    """
+            time_result = await conn.execute(text("""
                     SELECT AVG(EXTRACT(EPOCH FROM (completed_at - created_at))) as avg_seconds
                     FROM investigations
                     WHERE status = 'completed'
                     AND created_at > NOW() - INTERVAL '24 hours'
                     AND completed_at IS NOT NULL
-                    """
-                )
-            )
+                    """))
             avg_time = time_result.scalar()
             report["avg_processing_time_seconds"] = (
                 round(avg_time, 2) if avg_time else None
             )
 
             # Stuck investigations (still running after 1 hour)
-            stuck_result = await conn.execute(
-                text(
-                    """
+            stuck_result = await conn.execute(text("""
                     SELECT COUNT(*) FROM investigations
                     WHERE status = 'running'
                     AND created_at < NOW() - INTERVAL '1 hour'
-                    """
-                )
-            )
+                    """))
             report["currently_stuck"] = stuck_result.scalar() or 0
 
             report["status"] = "completed"

--- a/src/infrastructure/queue/tasks/maintenance_tasks.py
+++ b/src/infrastructure/queue/tasks/maintenance_tasks.py
@@ -269,15 +269,13 @@ async def _warm_cache_async() -> dict[str, Any]:
 
         # 1. Recent investigations
         try:
-            result = await db.execute(
-                """
+            result = await db.execute("""
                 SELECT id, query, status, findings
                 FROM investigations
                 WHERE created_at > NOW() - INTERVAL '7 days'
                 ORDER BY created_at DESC
                 LIMIT 20
-                """
-            )
+                """)
             investigations = result.fetchall()
 
             for inv in investigations:
@@ -299,14 +297,12 @@ async def _warm_cache_async() -> dict[str, Any]:
 
         # 2. Active API keys
         try:
-            result = await db.execute(
-                """
+            result = await db.execute("""
                 SELECT id, key_prefix, client_id, tier, status
                 FROM api_keys
                 WHERE status = 'active'
                 AND (expires_at IS NULL OR expires_at > NOW())
-                """
-            )
+                """)
             api_keys = result.fetchall()
 
             for key in api_keys:

--- a/src/models/entity_graph.py
+++ b/src/models/entity_graph.py
@@ -83,7 +83,9 @@ class EntityNode(BaseModel):
 
     # Extra data
     first_detected = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
-    last_detected = Column(DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    last_detected = Column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+    )
     extra_data = Column(JSON, default={})
 
     # Relationships
@@ -191,7 +193,9 @@ class EntityRelationship(BaseModel):
 
     # Evidence and detection
     first_detected = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
-    last_detected = Column(DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    last_detected = Column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+    )
     detection_count = Column(Integer, default=1)  # How many times detected
 
     # Investigation references (which investigations found this relationship)
@@ -349,7 +353,9 @@ class SuspiciousNetwork(BaseModel):
     # Investigation references
     investigation_ids = Column(JSON, default=[])  # Investigations that detected this
     first_detected = Column(DateTime, default=lambda: datetime.now(UTC))
-    last_detected = Column(DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    last_detected = Column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+    )
 
     # Financial impact
     total_contract_value = Column(Float, default=0.0)

--- a/src/models/ml_feedback.py
+++ b/src/models/ml_feedback.py
@@ -81,7 +81,9 @@ class InvestigationFeedback(Base):
     reviewed_by = Column(String(255), nullable=True)  # Expert reviewer
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC), index=True)
+    created_at = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC), index=True
+    )
     updated_at = Column(DateTime, nullable=True, onupdate=lambda: datetime.now(UTC))
 
     # Model version that made the prediction

--- a/src/models/ml_models.py
+++ b/src/models/ml_models.py
@@ -220,7 +220,9 @@ class AnomalyDetectorModelDB(Base):
     trained_at = Column(DateTime)
     deployed_at = Column(DateTime)
     created_at = Column(DateTime, default=lambda: datetime.now(UTC))
-    updated_at = Column(DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    updated_at = Column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+    )
 
     # Paths and references
     model_path = Column(Text)

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 def _utcnow() -> datetime:
     """Naive UTC datetime compatible with 'timestamp without time zone' columns."""
     return datetime.now(UTC).replace(tzinfo=None)
+
+
 from enum import Enum
 from typing import Any
 
@@ -95,7 +97,6 @@ class Intent:
             "confidence": self.confidence,
             "suggested_agent": self.suggested_agent,
         }
-
 
 
 class IntentDetector:
@@ -588,9 +589,7 @@ class ChatService:
         self.agents = None
         self._agents_initialized = False
 
-    async def get_or_create_session(
-        self, session_id: str, user_id: str | None = None
-    ):
+    async def get_or_create_session(self, session_id: str, user_id: str | None = None):
         """Get existing session or create new one (persisted to DB)."""
         from sqlalchemy import select
 
@@ -716,9 +715,7 @@ class ChatService:
         async with get_db_session() as db:
             # Delete messages (FK CASCADE would also handle this)
             await db.execute(
-                delete(DBChatMessage).where(
-                    DBChatMessage.session_id == session_id
-                )
+                delete(DBChatMessage).where(DBChatMessage.session_id == session_id)
             )
             # Mark session as cleared
             result = await db.execute(
@@ -762,9 +759,7 @@ class ChatService:
 
         async with get_db_session() as db:
             await db.execute(
-                delete(DBChatMessage).where(
-                    DBChatMessage.session_id == session_id
-                )
+                delete(DBChatMessage).where(DBChatMessage.session_id == session_id)
             )
             await db.execute(
                 delete(DBChatSession).where(DBChatSession.id == session_id)

--- a/tests/integration/api_audits/test_cpf_historical_dates.py
+++ b/tests/integration/api_audits/test_cpf_historical_dates.py
@@ -221,7 +221,9 @@ async def main():
         print(f"{Colors.OKGREEN}Conseguimos encontrar dados de salário!{Colors.ENDC}")
         print(f"{Colors.OKGREEN}Sistema está funcionando perfeitamente!{Colors.ENDC}")
     else:
-        print(f"{Colors.WARNING}{Colors.BOLD}⚠️  TESTE COMPLETO: SEM DADOS{Colors.ENDC}")
+        print(
+            f"{Colors.WARNING}{Colors.BOLD}⚠️  TESTE COMPLETO: SEM DADOS{Colors.ENDC}"
+        )
         print(f"{Colors.WARNING}Nenhuma data testada retornou dados{Colors.ENDC}")
         print_info("Possíveis causas:")
         print_info("  1. CPF não está na base federal (pode ser estadual/municipal)")

--- a/tests/integration/test_drummond_init.py
+++ b/tests/integration/test_drummond_init.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Test Drummond initialization locally"""
+
 import os
 import sys
 

--- a/tests/integration/test_drummond_live.py
+++ b/tests/integration/test_drummond_live.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Test Drummond agent on live HuggingFace deployment"""
+
 import json
 
 import requests

--- a/tests/manual/chat/test_chat_integration.py
+++ b/tests/manual/chat/test_chat_integration.py
@@ -7,6 +7,7 @@ Testa:
 2. Integração com Orchestrator
 3. Busca real em APIs governamentais
 """
+
 import asyncio
 import sys
 from pathlib import Path

--- a/tests/manual/chat/test_chat_real_scenarios.py
+++ b/tests/manual/chat/test_chat_real_scenarios.py
@@ -8,6 +8,7 @@ Valida se o sistema realmente faz o que promete:
 3. Análise multi-agente
 4. Respostas completas e precisas
 """
+
 import asyncio
 import sys
 from pathlib import Path

--- a/tests/manual/chat/test_production_chat.py
+++ b/tests/manual/chat/test_production_chat.py
@@ -3,6 +3,7 @@
 Teste em Produção - Chat API
 Testa a API real em produção (Railway)
 """
+
 import asyncio
 import sys
 
@@ -94,7 +95,9 @@ async def test_chat_entity_extraction():
                     print("✅ Resposta parece conter dados reais (não apenas R$ 0.00)")
                     checks.append(True)
                 else:
-                    print("⚠️  Resposta pode conter dados mockados (R$ 0.00 encontrado)")
+                    print(
+                        "⚠️  Resposta pode conter dados mockados (R$ 0.00 encontrado)"
+                    )
                     checks.append(False)
 
                 # Check 3: Sistema entendeu a query

--- a/tests/manual/test_entity_extraction_integration.py
+++ b/tests/manual/test_entity_extraction_integration.py
@@ -3,6 +3,7 @@
 Test Entity Extraction Integration with Zumbi
 Validates that entities are correctly passed to InvestigationRequest
 """
+
 import asyncio
 import sys
 from pathlib import Path

--- a/tests/manual/test_intent_classification.py
+++ b/tests/manual/test_intent_classification.py
@@ -3,6 +3,7 @@
 Test Intent Classification Improvements
 Validates that investigation queries are properly detected
 """
+
 import asyncio
 import sys
 from pathlib import Path

--- a/tests/manual/test_railway_database.py
+++ b/tests/manual/test_railway_database.py
@@ -2,6 +2,7 @@
 """
 Test Railway PostgreSQL Connection and Investigations Table
 """
+
 import sys
 
 import psycopg2
@@ -26,12 +27,10 @@ def main():
 
         # Check investigations table
         print("🔍 Verificando tabela investigations...")
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT COUNT(*) FROM information_schema.tables
             WHERE table_name = 'investigations'
-        """
-        )
+        """)
         table_exists = cursor.fetchone()[0]
 
         if table_exists:
@@ -43,15 +42,13 @@ def main():
 
         # Get table structure
         print("📋 Estrutura da tabela:")
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT column_name, data_type, is_nullable
             FROM information_schema.columns
             WHERE table_name = 'investigations'
             ORDER BY ordinal_position
             LIMIT 10
-        """
-        )
+        """)
         columns = cursor.fetchall()
         for col_name, col_type, nullable in columns:
             null_str = "NULL" if nullable == "YES" else "NOT NULL"
@@ -69,14 +66,12 @@ def main():
         # Show recent investigations
         if total > 0:
             print("🔍 Últimas 5 investigações:")
-            cursor.execute(
-                """
+            cursor.execute("""
                 SELECT id, user_id, status, total_records_analyzed, anomalies_found, created_at
                 FROM investigations
                 ORDER BY created_at DESC
                 LIMIT 5
-            """
-            )
+            """)
             investigations = cursor.fetchall()
             for inv_id, user_id, status, records, anomalies, created in investigations:
                 print(

--- a/tests/unit/services/test_auth_service.py
+++ b/tests/unit/services/test_auth_service.py
@@ -41,9 +41,7 @@ class TestGetPool:
         """Test pool creation."""
         mock_pool = AsyncMock()
 
-        with patch(
-            "src.services.auth_service.get_db_pool", return_value=mock_pool
-        ):
+        with patch("src.services.auth_service.get_db_pool", return_value=mock_pool):
             pool = await service.get_pool()
 
             assert pool is mock_pool
@@ -223,9 +221,10 @@ class TestAuthenticateUser:
         mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
 
-        with patch.object(
-            service, "_increment_failed_attempts"
-        ) as mock_increment, patch.object(service, "get_pool", return_value=mock_pool):
+        with (
+            patch.object(service, "_increment_failed_attempts") as mock_increment,
+            patch.object(service, "get_pool", return_value=mock_pool),
+        ):
             mock_increment.return_value = None
 
             result = await service.authenticate_user("testuser", "wrongpassword")
@@ -334,9 +333,7 @@ class TestTokenVerification:
             # Create a valid token
             token = service.create_access_token({"sub": "user123"})
 
-            with patch.object(
-                service, "_is_token_blacklisted", return_value=False
-            ):
+            with patch.object(service, "_is_token_blacklisted", return_value=False):
                 payload = await service.verify_token(token, token_type="access")
 
                 assert payload["sub"] == "user123"
@@ -351,9 +348,7 @@ class TestTokenVerification:
             # Create an access token
             token = service.create_access_token({"sub": "user123"})
 
-            with patch.object(
-                service, "_is_token_blacklisted", return_value=False
-            ):
+            with patch.object(service, "_is_token_blacklisted", return_value=False):
                 with pytest.raises(AuthenticationError, match="Invalid token type"):
                     await service.verify_token(token, token_type="refresh")
 
@@ -365,9 +360,7 @@ class TestTokenVerification:
 
             token = service.create_access_token({"sub": "user123"})
 
-            with patch.object(
-                service, "_is_token_blacklisted", return_value=True
-            ):
+            with patch.object(service, "_is_token_blacklisted", return_value=True):
                 with pytest.raises(AuthenticationError, match="revoked"):
                     await service.verify_token(token)
 
@@ -487,9 +480,10 @@ class TestGetCurrentUser:
             )
             mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            with patch.object(
-                service, "_is_token_blacklisted", return_value=False
-            ), patch.object(service, "get_pool", return_value=mock_pool):
+            with (
+                patch.object(service, "_is_token_blacklisted", return_value=False),
+                patch.object(service, "get_pool", return_value=mock_pool),
+            ):
                 result = await service.get_current_user(token)
 
                 assert result is not None
@@ -634,11 +628,11 @@ class TestRefreshAccessToken:
                 "created_at": datetime.now(UTC),
             }
 
-            with patch.object(
-                service, "_is_token_blacklisted", return_value=False
-            ), patch.object(service, "get_current_user", return_value=user_data), patch.object(
-                service, "revoke_token"
-            ) as mock_revoke:
+            with (
+                patch.object(service, "_is_token_blacklisted", return_value=False),
+                patch.object(service, "get_current_user", return_value=user_data),
+                patch.object(service, "revoke_token") as mock_revoke,
+            ):
                 result = await service.refresh_access_token(refresh_token)
 
                 assert "access_token" in result
@@ -656,9 +650,10 @@ class TestRefreshAccessToken:
 
             refresh_token = service.create_refresh_token({"sub": str(user_id)})
 
-            with patch.object(
-                service, "_is_token_blacklisted", return_value=False
-            ), patch.object(service, "get_current_user", return_value=None):
+            with (
+                patch.object(service, "_is_token_blacklisted", return_value=False),
+                patch.object(service, "get_current_user", return_value=None),
+            ):
                 with pytest.raises(AuthenticationError, match="not found"):
                     await service.refresh_access_token(refresh_token)
 

--- a/tests/unit/services/test_cache_service.py
+++ b/tests/unit/services/test_cache_service.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from redis.exceptions import RedisError
 
-from src.services.cache_service import CacheService, CacheTTL, cache_result, cache_service
+from src.services.cache_service import (
+    CacheService,
+    CacheTTL,
+    cache_result,
+    cache_service,
+)
 
 
 class TestCacheTTL:
@@ -106,9 +111,7 @@ class TestCacheServiceOperations:
         """Test cache miss returns None."""
         service.redis.get = AsyncMock(return_value=None)
 
-        with patch(
-            "src.services.cache_service.metrics_manager.increment_counter"
-        ):
+        with patch("src.services.cache_service.metrics_manager.increment_counter"):
             result = await service.get("cidadao:test:nonexistent")
 
             assert result is None
@@ -120,9 +123,7 @@ class TestCacheServiceOperations:
         compressed = zlib.compress(original)
         service.redis.get = AsyncMock(return_value=compressed)
 
-        with patch(
-            "src.services.cache_service.metrics_manager.increment_counter"
-        ):
+        with patch("src.services.cache_service.metrics_manager.increment_counter"):
             result = await service.get("cidadao:test:key", decompress=True)
 
             assert result == {"data": "test"}
@@ -132,9 +133,7 @@ class TestCacheServiceOperations:
         """Test Redis error handling in get."""
         service.redis.get = AsyncMock(side_effect=RedisError("Connection failed"))
 
-        with patch(
-            "src.services.cache_service.metrics_manager.increment_counter"
-        ):
+        with patch("src.services.cache_service.metrics_manager.increment_counter"):
             result = await service.get("cidadao:test:key")
 
             assert result is None
@@ -159,12 +158,8 @@ class TestCacheServiceOperations:
         """Test setting dict value."""
         service.redis.setex = AsyncMock()
 
-        with patch(
-            "src.services.cache_service.metrics_manager.observe_histogram"
-        ):
-            result = await service.set(
-                "cidadao:test:key", {"data": "value"}, ttl=300
-            )
+        with patch("src.services.cache_service.metrics_manager.observe_histogram"):
+            result = await service.set("cidadao:test:key", {"data": "value"}, ttl=300)
 
             assert result is True
             service.redis.setex.assert_called_once()
@@ -175,9 +170,7 @@ class TestCacheServiceOperations:
         service.redis.setex = AsyncMock()
         large_value = {"data": "x" * 2000}
 
-        with patch(
-            "src.services.cache_service.metrics_manager.observe_histogram"
-        ):
+        with patch("src.services.cache_service.metrics_manager.observe_histogram"):
             result = await service.set(
                 "cidadao:test:key", large_value, ttl=300, compress=True
             )
@@ -189,9 +182,7 @@ class TestCacheServiceOperations:
         """Test setting without TTL."""
         service.redis.set = AsyncMock()
 
-        with patch(
-            "src.services.cache_service.metrics_manager.observe_histogram"
-        ):
+        with patch("src.services.cache_service.metrics_manager.observe_histogram"):
             result = await service.set("cidadao:test:key", "value")
 
             assert result is True
@@ -202,10 +193,9 @@ class TestCacheServiceOperations:
         """Test Redis error handling in set."""
         service.redis.setex = AsyncMock(side_effect=RedisError("Write failed"))
 
-        with patch(
-            "src.services.cache_service.metrics_manager.observe_histogram"
-        ), patch(
-            "src.services.cache_service.metrics_manager.increment_counter"
+        with (
+            patch("src.services.cache_service.metrics_manager.observe_histogram"),
+            patch("src.services.cache_service.metrics_manager.increment_counter"),
         ):
             result = await service.set("cidadao:test:key", "value", ttl=300)
 
@@ -274,9 +264,10 @@ class TestChatCaching:
             "hit_count": 5,
         }
 
-        with patch.object(service, "get") as mock_get, patch.object(
-            service, "set"
-        ) as mock_set:
+        with (
+            patch.object(service, "get") as mock_get,
+            patch.object(service, "set") as mock_set,
+        ):
             mock_get.return_value = cached_data
             mock_set.return_value = True
 
@@ -336,9 +327,10 @@ class TestSessionCaching:
     @pytest.mark.asyncio
     async def test_update_session_field_existing(self, service):
         """Test updating field in existing session."""
-        with patch.object(service, "get_session_state") as mock_get, patch.object(
-            service, "save_session_state"
-        ) as mock_save:
+        with (
+            patch.object(service, "get_session_state") as mock_get,
+            patch.object(service, "save_session_state") as mock_save,
+        ):
             mock_get.return_value = {"existing": "data"}
             mock_save.return_value = True
 
@@ -354,15 +346,14 @@ class TestSessionCaching:
     @pytest.mark.asyncio
     async def test_update_session_field_new_session(self, service):
         """Test updating field in new session."""
-        with patch.object(service, "get_session_state") as mock_get, patch.object(
-            service, "save_session_state"
-        ) as mock_save:
+        with (
+            patch.object(service, "get_session_state") as mock_get,
+            patch.object(service, "save_session_state") as mock_save,
+        ):
             mock_get.return_value = None
             mock_save.return_value = True
 
-            result = await service.update_session_field(
-                "session-new", "field", "value"
-            )
+            result = await service.update_session_field("session-new", "field", "value")
 
             assert result is True
 
@@ -563,9 +554,7 @@ class TestStampedeProtection:
         mock_pipeline.execute = AsyncMock(return_value=[None, -2])
         service.redis.pipeline = MagicMock(return_value=mock_pipeline)
 
-        result = await service.get_with_stampede_protection(
-            "cidadao:test:key", ttl=300
-        )
+        result = await service.get_with_stampede_protection("cidadao:test:key", ttl=300)
 
         assert result is None
 
@@ -575,14 +564,10 @@ class TestStampedeProtection:
         mock_pipeline = AsyncMock()
         mock_pipeline.get = MagicMock()
         mock_pipeline.ttl = MagicMock()
-        mock_pipeline.execute = AsyncMock(
-            return_value=['{"data": "value"}', 250]
-        )
+        mock_pipeline.execute = AsyncMock(return_value=['{"data": "value"}', 250])
         service.redis.pipeline = MagicMock(return_value=mock_pipeline)
 
-        result = await service.get_with_stampede_protection(
-            "cidadao:test:key", ttl=300
-        )
+        result = await service.get_with_stampede_protection("cidadao:test:key", ttl=300)
 
         assert result == {"data": "value"}
 
@@ -598,8 +583,9 @@ class TestCacheDecorator:
         async def expensive_function(x):
             return x * 2
 
-        with patch.object(CacheService, "get") as mock_get, patch.object(
-            CacheService, "set"
+        with (
+            patch.object(CacheService, "get") as mock_get,
+            patch.object(CacheService, "set"),
         ):
             mock_get.return_value = 10
 
@@ -615,9 +601,10 @@ class TestCacheDecorator:
         async def expensive_function(x):
             return x * 2
 
-        with patch.object(CacheService, "get") as mock_get, patch.object(
-            CacheService, "set"
-        ) as mock_set:
+        with (
+            patch.object(CacheService, "get") as mock_get,
+            patch.object(CacheService, "set") as mock_set,
+        ):
             mock_get.return_value = None
             mock_set.return_value = True
 
@@ -635,9 +622,10 @@ class TestCacheServiceLifecycle:
         """Test successful initialization."""
         service = CacheService()
 
-        with patch(
-            "src.services.cache_service.ConnectionPool.from_url"
-        ) as mock_pool, patch("src.services.cache_service.redis.Redis") as mock_redis:
+        with (
+            patch("src.services.cache_service.ConnectionPool.from_url") as mock_pool,
+            patch("src.services.cache_service.redis.Redis") as mock_redis,
+        ):
             mock_redis_instance = AsyncMock()
             mock_redis_instance.ping = AsyncMock()
             mock_redis.return_value = mock_redis_instance
@@ -654,9 +642,7 @@ class TestCacheServiceLifecycle:
         service = CacheService()
         service._initialized = True
 
-        with patch(
-            "src.services.cache_service.ConnectionPool.from_url"
-        ) as mock_pool:
+        with patch("src.services.cache_service.ConnectionPool.from_url") as mock_pool:
             await service.initialize()
 
             mock_pool.assert_not_called()
@@ -666,9 +652,7 @@ class TestCacheServiceLifecycle:
         """Test initialization failure."""
         service = CacheService()
 
-        with patch(
-            "src.services.cache_service.ConnectionPool.from_url"
-        ) as mock_pool:
+        with patch("src.services.cache_service.ConnectionPool.from_url") as mock_pool:
             mock_pool.side_effect = Exception("Connection failed")
 
             with pytest.raises(Exception):

--- a/tests/unit/services/test_data_service.py
+++ b/tests/unit/services/test_data_service.py
@@ -120,9 +120,7 @@ class TestFetchContracts:
         """Test error handling returns empty list."""
         with patch.object(service, "_get_api_client") as mock_get_client:
             mock_client = AsyncMock()
-            mock_client.get_contracts = AsyncMock(
-                side_effect=Exception("API Error")
-            )
+            mock_client.get_contracts = AsyncMock(side_effect=Exception("API Error"))
             mock_get_client.return_value = mock_client
 
             result = await service.fetch_contracts()
@@ -268,9 +266,7 @@ class TestGetRecentContractIds:
     async def test_get_recent_ids_fetches_when_empty(self, service):
         """Test fetching when cache is empty."""
         mock_response = MagicMock()
-        mock_response.data = [
-            {"id": f"new-{i}"} for i in range(10)
-        ]
+        mock_response.data = [{"id": f"new-{i}"} for i in range(10)]
 
         with patch.object(service, "_get_api_client") as mock_get_client:
             mock_client = AsyncMock()
@@ -287,9 +283,7 @@ class TestGetRecentContractIds:
         """Test error handling returns empty list."""
         with patch.object(service, "_get_api_client") as mock_get_client:
             mock_client = AsyncMock()
-            mock_client.get_contracts = AsyncMock(
-                side_effect=Exception("Timeout")
-            )
+            mock_client.get_contracts = AsyncMock(side_effect=Exception("Timeout"))
             mock_get_client.return_value = mock_client
 
             result = await service.get_recent_contract_ids()
@@ -343,9 +337,7 @@ class TestFetchExpenses:
         """Test error handling returns empty list."""
         with patch.object(service, "_get_api_client") as mock_get_client:
             mock_client = AsyncMock()
-            mock_client.get_expenses = AsyncMock(
-                side_effect=Exception("API Error")
-            )
+            mock_client.get_expenses = AsyncMock(side_effect=Exception("API Error"))
             mock_get_client.return_value = mock_client
 
             result = await service.fetch_expenses()
@@ -384,9 +376,7 @@ class TestFetchAgreements:
         """Test error handling returns empty list."""
         with patch.object(service, "_get_api_client") as mock_get_client:
             mock_client = AsyncMock()
-            mock_client.get_agreements = AsyncMock(
-                side_effect=Exception("API Error")
-            )
+            mock_client.get_agreements = AsyncMock(side_effect=Exception("API Error"))
             mock_get_client.return_value = mock_client
 
             result = await service.fetch_agreements()

--- a/tests/unit/services/test_investigation_service.py
+++ b/tests/unit/services/test_investigation_service.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.models.investigation import Investigation
-from src.services.investigation_service import InvestigationService, investigation_service
+from src.services.investigation_service import (
+    InvestigationService,
+    investigation_service,
+)
 
 
 class TestInvestigationServiceInitialization:
@@ -43,9 +46,7 @@ class TestCreate:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             # Setup context manager
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
@@ -78,9 +79,7 @@ class TestCreate:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -135,9 +134,7 @@ class TestUpdateStatus:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -165,9 +162,7 @@ class TestUpdateStatus:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -195,9 +190,7 @@ class TestUpdateStatus:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -224,9 +217,7 @@ class TestUpdateStatus:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -254,9 +245,7 @@ class TestUpdateStatus:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -289,9 +278,7 @@ class TestGetById:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -310,9 +297,7 @@ class TestGetById:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -348,9 +333,7 @@ class TestSearch:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -375,9 +358,7 @@ class TestSearch:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -402,9 +383,7 @@ class TestSearch:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -428,9 +407,7 @@ class TestSearch:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -465,9 +442,7 @@ class TestCancel:
         mock_db.commit = AsyncMock()
         mock_db.refresh = AsyncMock()
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -488,9 +463,7 @@ class TestCancel:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -513,9 +486,7 @@ class TestCancel:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -538,9 +509,7 @@ class TestCancel:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -563,9 +532,7 @@ class TestCancel:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)
@@ -588,9 +555,7 @@ class TestCancel:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch(
-            "src.services.investigation_service.get_db_session"
-        ) as mock_session:
+        with patch("src.services.investigation_service.get_db_session") as mock_session:
             mock_context = AsyncMock()
             mock_context.__aenter__ = AsyncMock(return_value=mock_db)
             mock_context.__aexit__ = AsyncMock(return_value=None)

--- a/tests/voice/test_voice_quick.py
+++ b/tests/voice/test_voice_quick.py
@@ -2,6 +2,7 @@
 """
 Teste rápido de vozes Chirp3-HD - 4 agentes para demonstração
 """
+
 import os
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Resumo

Aplica o `black` em 30 arquivos de `src/` e `tests/` que estavam fora do padrão do projeto (line-length 88, target py311/py312). Reformatação mecânica — sem mudança de lógica, comportamento ou API.

## Motivação

O check `Code formatting check (Black)` no workflow `Tests & Code Quality` é **bloqueante** no CI (ao contrário de isort e Ruff, que são non-blocking). Por causa disso, qualquer PR novo aberto contra `main` quebra mesmo quando não toca em nenhum dos 30 arquivos com dívida — basta o Black inspecionar o repo inteiro.

Exemplo concreto: PR de documentação (issue #5, agentes Nanã e Monteiro Lobato) acabou de quebrar o CI sem mexer em código.

## Diff

- 30 arquivos, +209/-307 linhas (líquido -98, típico do Black agrupando continuations)
- Categorias: `src/api/`, `src/agents/`, `src/infrastructure/`, `src/models/`, `src/services/`, `tests/integration/`, `tests/manual/`, `tests/unit/`, `tests/voice/`

## Pendências fora do escopo deste PR

- **isort**: 13 arquivos com imports fora de ordem (non-blocking no CI)
- **Ruff**: 38 erros (não-autofixáveis após `ruff check --fix`), majoritariamente em `tests/` (`SIM117`, `S113`, `B017`). Não-blocking.

Ambos podem virar PR separado para limpar a dívida e endurecer o CI no futuro.