### PR TITLE
fix: add missing return type annotation to AnalysisService.__init__

### DIFF
--- a/src/services/analysis_service.py
+++ b/src/services/analysis_service.py
@@ -4,7 +4,7 @@
 class AnalysisService:
     """Service for data analysis operations."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._analysis_cache = {}
 
     async def analyze_spending_patterns(self, data: list[dict]) -> dict:


### PR DESCRIPTION
## Summary
Adds missing `-> None` return type annotation to `AnalysisService.__init__` to fix mypy `no-untyped-def` error.
Closes #15

## Root Cause
`src/services/analysis_service.py:7` has `def __init__(self):` without an explicit return type annotation. Mypy's `no-untyped-def` check flags this as an error since PEP 484 recommends all functions have type annotations when the check is enabled.

## Fix
Added `-> None` to the `__init__` method signature: `def __init__(self) -> None:`

## Changes
- `src/services/analysis_service.py` (+1 -1): Added `-> None` return type annotation

## Testing
- ✅ `__init__` should always return None per Python convention
- ✅ No other methods affected
- ✅ Mypy `no-untyped-def` check should now pass for this file