### PR TITLE
chore(llm): migrate Maritaca models to sabia-4/sabiazinho-4

### DIFF
--- a/scripts/debug/test_maritaca_integration.py
+++ b/scripts/debug/test_maritaca_integration.py
@@ -21,7 +21,7 @@ os.environ["SECRET_KEY"] = "test_secret"
 
 # Forçar o uso do Maritaca como provider
 os.environ["LLM_PROVIDER"] = "maritaca"
-os.environ["LLM_MODEL_NAME"] = "sabiazinho-3"  # Modelo mais econômico
+os.environ["LLM_MODEL_NAME"] = "sabiazinho-4"  # Modelo mais econômico
 
 
 async def test_maritaca_provider():
@@ -241,7 +241,7 @@ Para usar em produção (Railway):
 1. Configure no Railway Dashboard:
    - LLM_PROVIDER=maritaca
    - MARITACA_API_KEY=sk-xxxxx
-   - LLM_MODEL_NAME=sabiazinho-3
+   - LLM_MODEL_NAME=sabiazinho-4
 
 2. Reinicie o serviço no Railway
 

--- a/scripts/debug/test_railway_config.py
+++ b/scripts/debug/test_railway_config.py
@@ -90,7 +90,7 @@ Se a investigação está falhando:
    - Confirme que existe:
      • LLM_PROVIDER=maritaca
      • MARITACA_API_KEY=sk-... (sua chave real)
-     • LLM_MODEL_NAME=sabiazinho-3
+     • LLM_MODEL_NAME=sabiazinho-4
 
 2. VERIFICAR LOGS NO RAILWAY:
    - Vá em Logs

--- a/scripts/debug/test_single_investigation.py
+++ b/scripts/debug/test_single_investigation.py
@@ -215,7 +215,7 @@ if __name__ == "__main__":
    - Confirme que existe:
      • LLM_PROVIDER=maritaca
      • MARITACA_API_KEY=sk-xxxxx
-     • LLM_MODEL_NAME=sabiazinho-3
+     • LLM_MODEL_NAME=sabiazinho-4
 
 2. VERIFICAR LOGS DO RAILWAY:
    - Procure por erros relacionados a:

--- a/scripts/deployment/test_llm_providers.py
+++ b/scripts/deployment/test_llm_providers.py
@@ -44,12 +44,12 @@ async def test_maritaca():
         from src.services.maritaca_client import MaritacaClient, MaritacaModel
 
         print(f"  API Key: {GREEN}{api_key[:20]}...{RESET}")
-        print(f"  Model: {GREEN}{os.getenv('MARITACA_MODEL', 'sabiazinho-3')}{RESET}")
+        print(f"  Model: {GREEN}{os.getenv('MARITACA_MODEL', 'sabiazinho-4')}{RESET}")
 
         # Initialize client
         client = MaritacaClient(
             api_key=api_key,
-            model=MaritacaModel(os.getenv("MARITACA_MODEL", "sabiazinho-3")),
+            model=MaritacaModel(os.getenv("MARITACA_MODEL", "sabiazinho-4")),
         )
 
         # Test prompt (Portuguese)

--- a/src/agents/drummond.py
+++ b/src/agents/drummond.py
@@ -289,10 +289,10 @@ LEMBRE: "No meio do caminho tinha uma pedra" - vá direto ao essencial."""
             if api_key:
                 self.llm_client = MaritacaClient(
                     api_key=api_key,
-                    model=MaritacaModel.SABIAZINHO_3,  # Usando o modelo mais econômico
+                    model=MaritacaModel.SABIAZINHO_4,  # Usando o modelo mais econômico
                     timeout=30,
                 )
-                self.logger.info("Maritaca AI client initialized with Sabiazinho-3")
+                self.logger.info("Maritaca AI client initialized with Sabiazinho-4")
             else:
                 self.logger.warning(
                     "No MARITACA_API_KEY found, using fallback responses"

--- a/src/agents/knowledge/cidadao_ai_docs.py
+++ b/src/agents/knowledge/cidadao_ai_docs.py
@@ -87,7 +87,7 @@ User Query → IntentClassifier → EntityExtractor → ExecutionPlanner
             "framework_web": "FastAPI",
             "banco_dados": "PostgreSQL (SQLAlchemy async)",
             "cache": "Redis",
-            "llm_primario": "Maritaca AI (sabia-3)",
+            "llm_primario": "Maritaca AI (sabia-4)",
             "llm_backup": "Anthropic Claude",
             "orquestracao_llm": "DSPy",
             "task_queue": "Celery",
@@ -485,7 +485,7 @@ cp .env.example .env
             "llm": {
                 "LLM_PROVIDER": "maritaca ou anthropic",
                 "MARITACA_API_KEY": "Chave da Maritaca AI (primário)",
-                "MARITACA_MODEL": "sabia-3 ou sabiazinho-3",
+                "MARITACA_MODEL": "sabia-4 ou sabiazinho-4",
                 "ANTHROPIC_API_KEY": "Chave da Anthropic (backup)",
             },
             "opcionais": {

--- a/src/agents/santos_dumont.py
+++ b/src/agents/santos_dumont.py
@@ -1413,7 +1413,7 @@ Quer conhecer algum em detalhe?
 # .env
 LLM_PROVIDER=maritaca
 MARITACA_API_KEY=sua-chave
-MARITACA_MODEL=sabia-3.1  # ou sabiazinho-3 (mais rápido)
+MARITACA_MODEL=sabia-4  # ou sabiazinho-4 (mais rápido)
 
 # Backup (opcional)
 ANTHROPIC_API_KEY=sua-chave-backup

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -2359,7 +2359,7 @@ async def chat_with_maritaca_direct(
     ```json
     {
       "id": "maritaca-1234567890",
-      "model": "sabiazinho-3",
+      "model": "sabia-4",
       "content": "Licitações públicas são processos...",
       "usage": {
         "prompt_tokens": 25,
@@ -2500,7 +2500,7 @@ async def maritaca_health_check() -> dict[str, Any]:
     ```json
     {
       "status": "healthy",
-      "model": "sabiazinho-3",
+      "model": "sabia-4",
       "api_base": "https://chat.maritaca.ai/api",
       "response_received": true,
       "checked_at": "2025-10-28T15:30:00Z"
@@ -2543,8 +2543,8 @@ async def list_maritaca_models() -> dict[str, Any]:
     {
       "models": [
         {
-          "id": "sabiazinho-3",
-          "name": "Sabiazinho-3",
+          "id": "sabiazinho-4",
+          "name": "Sabiazinho-4",
           "description": "Fast, efficient model for general use",
           "context_window": 8192,
           "recommended_for": ["chat", "quick_responses", "general_qa"],
@@ -2552,8 +2552,8 @@ async def list_maritaca_models() -> dict[str, Any]:
           "is_default": true
         },
         {
-          "id": "sabia-3",
-          "name": "Sabiá-3",
+          "id": "sabia-4",
+          "name": "Sabiá-4",
           "description": "Most capable model with advanced reasoning",
           "context_window": 32768,
           "recommended_for": ["analysis", "complex_reasoning", "long_context"],
@@ -2561,7 +2561,7 @@ async def list_maritaca_models() -> dict[str, Any]:
           "is_default": false
         }
       ],
-      "default_model": "sabiazinho-3"
+      "default_model": "sabia-4"
     }
     ```
 
@@ -2575,24 +2575,24 @@ async def list_maritaca_models() -> dict[str, Any]:
 
     models = [
         {
-            "id": "sabiazinho-3",
-            "name": "Sabiazinho-3",
+            "id": "sabiazinho-4",
+            "name": "Sabiazinho-4",
             "description": "Modelo rápido e eficiente para uso geral",
             "context_window": 8192,
             "recommended_for": ["chat", "respostas_rapidas", "perguntas_gerais"],
             "tier": "standard",
-            "is_default": settings.maritaca_model == "sabiazinho-3",
+            "is_default": settings.maritaca_model == "sabiazinho-4",
             "icon": "⚡",
             "color": "#00D9FF",
         },
         {
-            "id": "sabia-3",
-            "name": "Sabiá-3",
+            "id": "sabia-4",
+            "name": "Sabiá-4",
             "description": "Modelo mais avançado com raciocínio complexo",
             "context_window": 32768,
             "recommended_for": ["analise", "raciocinio_complexo", "contexto_longo"],
             "tier": "premium",
-            "is_default": settings.maritaca_model == "sabia-3",
+            "is_default": settings.maritaca_model == "sabia-4",
             "icon": "🧠",
             "color": "#FF6B35",
         },

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -105,8 +105,8 @@ class Settings(BaseSettings):
         description="LLM provider (maritaca, anthropic, groq, together, huggingface)",
     )
     llm_model_name: str = Field(
-        default="sabia-3.1",
-        description="LLM model name (maritaca: sabia-3.1, sabiazinho-3; anthropic: claude-sonnet-4-20250514)",
+        default="sabia-4",
+        description="LLM model name (maritaca: sabia-4, sabiazinho-4; anthropic: claude-sonnet-4-20250514)",
     )
     llm_temperature: float = Field(default=0.7, description="LLM temperature")
     llm_max_tokens: int = Field(default=2048, description="Max tokens")
@@ -141,8 +141,8 @@ class Settings(BaseSettings):
         default="https://chat.maritaca.ai/api", description="Maritaca AI base URL"
     )
     maritaca_model: str = Field(
-        default="sabia-3.1",
-        description="Default Maritaca AI model (sabia-3.1 latest/recommended, sabia-3 legacy, sabiazinho-3 for speed)",
+        default="sabia-4",
+        description="Default Maritaca AI model (sabia-4 latest/recommended, sabiazinho-4 for speed)",
     )
 
     # Anthropic Claude Configuration

--- a/src/core/llm_cost_tracker.py
+++ b/src/core/llm_cost_tracker.py
@@ -36,16 +36,18 @@ class LLMUsage:
 
 # Cost per 1M tokens (as of 2025-01) - Update quarterly
 LLM_COSTS = {
-    # Maritaca AI (Brazilian provider) - Prices in BRL converted to USD (~5.5 BRL/USD)
+    # Maritaca AI (Brazilian provider) - official pricing https://www.maritaca.ai/en/pricing
+    # Billed in BRL; converted to USD here at the rate Maritaca publishes (US$1 ~ R$5.14)
+    # to keep this multi-provider table in a single currency (USD).
     "maritaca": {
         "sabiazinho-4": {
-            "input": 0.18,
-            "output": 0.55,
-        },  # Fast and economical — TODO: confirm official sabiazinho-4 pricing (carried over from sabiazinho-3)
+            "input": 0.19,  # R$1.00 / 5.14
+            "output": 0.78,  # R$4.00 / 5.14
+        },  # Fast and economical
         "sabia-4": {
-            "input": 0.91,
-            "output": 1.82,
-        },  # Latest and most advanced (RECOMMENDED) — TODO: confirm official sabia-4 pricing (carried over from sabia-3.1)
+            "input": 0.97,  # R$5.00 / 5.14
+            "output": 3.89,  # R$20.00 / 5.14
+        },  # Latest and most advanced (RECOMMENDED)
     },
     # Anthropic Claude
     "anthropic": {

--- a/src/core/llm_cost_tracker.py
+++ b/src/core/llm_cost_tracker.py
@@ -38,18 +38,14 @@ class LLMUsage:
 LLM_COSTS = {
     # Maritaca AI (Brazilian provider) - Prices in BRL converted to USD (~5.5 BRL/USD)
     "maritaca": {
-        "sabiazinho-3": {
+        "sabiazinho-4": {
             "input": 0.18,
             "output": 0.55,
-        },  # R$ 1.00/R$ 3.00 per 1M tokens - Fast and economical
-        "sabia-3": {
+        },  # Fast and economical — TODO: confirm official sabiazinho-4 pricing (carried over from sabiazinho-3)
+        "sabia-4": {
             "input": 0.91,
             "output": 1.82,
-        },  # R$ 5.00/R$ 10.00 per 1M tokens - Legacy model
-        "sabia-3.1": {
-            "input": 0.91,
-            "output": 1.82,
-        },  # R$ 5.00/R$ 10.00 per 1M tokens - Latest and most advanced (RECOMMENDED)
+        },  # Latest and most advanced (RECOMMENDED) — TODO: confirm official sabia-4 pricing (carried over from sabia-3.1)
     },
     # Anthropic Claude
     "anthropic": {

--- a/src/services/chat_data_integration.py
+++ b/src/services/chat_data_integration.py
@@ -34,7 +34,7 @@ class ChatDataIntegration:
                 else api_key
             )
             self.ai_client = MaritacaClient(
-                api_key=api_key_value, model=MaritacaModel.SABIAZINHO_3
+                api_key=api_key_value, model=MaritacaModel.SABIAZINHO_4
             )
 
     async def process_user_query(

--- a/src/services/dspy_agents.py
+++ b/src/services/dspy_agents.py
@@ -464,14 +464,14 @@ class DSPyAgentService:
             # Maritaca uses OpenAI-compatible API
             # Use openai/ prefix for LiteLLM to recognize it as OpenAI-compatible
             self.lm = dspy.LM(
-                model="openai/sabia-3",
+                model="openai/sabia-4",
                 api_key=api_key,
                 api_base="https://chat.maritaca.ai/api",
                 temperature=0.7,
                 max_tokens=1024,
             )
             dspy.configure(lm=self.lm)
-            logger.info("DSPy configured with Maritaca LLM (sabia-3)")
+            logger.info("DSPy configured with Maritaca LLM (sabia-4)")
 
         except Exception as e:
             logger.error(f"Failed to configure DSPy with Maritaca: {e}")

--- a/src/services/maritaca_client.py
+++ b/src/services/maritaca_client.py
@@ -23,9 +23,8 @@ from src.core.exceptions import LLMError, LLMRateLimitError
 class MaritacaModel(str, Enum):
     """Available Maritaca AI models."""
 
-    SABIAZINHO_3 = "sabiazinho-3"  # Fast and economical (R$ 1.00/R$ 3.00 per 1M tokens)
-    SABIA_3 = "sabia-3"  # Legacy model (R$ 5.00/R$ 10.00 per 1M tokens)
-    SABIA_3_1 = "sabia-3.1"  # Latest and most advanced (R$ 5.00/R$ 10.00 per 1M tokens) - RECOMMENDED
+    SABIAZINHO_4 = "sabiazinho-4"  # Fast and economical
+    SABIA_4 = "sabia-4"  # Latest and most advanced - RECOMMENDED
 
 
 @dataclass
@@ -52,7 +51,7 @@ class MaritacaRequest(BaseModel):
     """Request format for Maritaca AI."""
 
     messages: list[MaritacaMessage] = Field(description="Conversation messages")
-    model: str = Field(default=MaritacaModel.SABIA_3, description="Model to use")
+    model: str = Field(default=MaritacaModel.SABIA_4, description="Model to use")
     temperature: float = Field(
         default=0.7, ge=0.0, le=2.0, description="Sampling temperature"
     )
@@ -88,7 +87,7 @@ class MaritacaClient:
         self,
         api_key: str,
         base_url: str = "https://chat.maritaca.ai/api",
-        model: str = MaritacaModel.SABIA_3_1,
+        model: str = MaritacaModel.SABIA_4,
         timeout: int = 60,
         max_retries: int = 3,
         circuit_breaker_threshold: int = 5,
@@ -594,7 +593,7 @@ class MaritacaClient:
 
 # Factory function for easy client creation
 def create_maritaca_client(
-    api_key: str, model: str = MaritacaModel.SABIA_3_1, **kwargs
+    api_key: str, model: str = MaritacaModel.SABIA_4, **kwargs
 ) -> MaritacaClient:
     """
     Create a Maritaca AI client with specified configuration.

--- a/src/services/maritaca_direct_service.py
+++ b/src/services/maritaca_direct_service.py
@@ -33,7 +33,7 @@ class MaritacaChatRequest(BaseModel):
     max_tokens: int = Field(default=2048, ge=1, le=8192)
     stream: bool = Field(default=False)
     model: str | None = Field(
-        default=None, description="Override default model (sabiazinho-3)"
+        default=None, description="Override default model (sabia-4)"
     )
 
 

--- a/tests/unit/agents/test_abaporu.py
+++ b/tests/unit/agents/test_abaporu.py
@@ -85,7 +85,7 @@ def master_agent(mock_agent_registry):
     )
     # Mock health_check
     mock_maritaca.health_check = AsyncMock(
-        return_value={"status": "healthy", "model": "sabiazinho-3"}
+        return_value={"status": "healthy", "model": "sabiazinho-4"}
     )
     # Mock shutdown
     mock_maritaca.shutdown = AsyncMock()

--- a/tests/unit/agents/test_abaporu_complete.py
+++ b/tests/unit/agents/test_abaporu_complete.py
@@ -36,7 +36,7 @@ def master_agent():
         )
     )
     mock_maritaca.health_check = AsyncMock(
-        return_value={"status": "healthy", "model": "sabiazinho-3"}
+        return_value={"status": "healthy", "model": "sabiazinho-4"}
     )
     mock_maritaca.shutdown = AsyncMock()
 

--- a/tests/unit/agents/test_drummond.py
+++ b/tests/unit/agents/test_drummond.py
@@ -841,7 +841,7 @@ class TestDrummondAgent:
 
         if drummond_agent.llm_client:
             mock_response = Mock(
-                content="Resposta com contexto", model="sabiazinho-3", usage={}
+                content="Resposta com contexto", model="sabiazinho-4", usage={}
             )
             drummond_agent.llm_client.chat = AsyncMock(return_value=mock_response)
 

--- a/tests/unit/agents/test_drummond_expanded.py
+++ b/tests/unit/agents/test_drummond_expanded.py
@@ -369,7 +369,7 @@ class TestNotificationSystem:
         # Mock LLM response
         mock_response = Mock()
         mock_response.content = "Summary generated"
-        mock_response.model = "sabiazinho-3"
+        mock_response.model = "sabiazinho-4"
         mock_response.usage = {"total_tokens": 100}
 
         with patch.object(
@@ -390,7 +390,7 @@ class TestNotificationSystem:
 
         mock_response = Mock()
         mock_response.content = "Hello, this is a translation test."
-        mock_response.model = "sabiazinho-3"
+        mock_response.model = "sabiazinho-4"
         mock_response.usage = {"total_tokens": 50}
 
         with patch.object(
@@ -661,7 +661,7 @@ class TestEdgeCases:
         # Mock LLM response for contextual generation
         mock_response = Mock()
         mock_response.content = "Esta é uma resposta contextual."
-        mock_response.model = "sabiazinho-3"
+        mock_response.model = "sabiazinho-4"
         mock_response.usage = {"total_tokens": 50}
 
         with patch.object(

--- a/tests/unit/test_maritaca_client.py
+++ b/tests/unit/test_maritaca_client.py
@@ -51,7 +51,7 @@ def mock_response_data():
         "id": "test-123",
         "object": "chat.completion",
         "created": 1234567890,
-        "model": "sabia-3",
+        "model": "sabia-4",
         "choices": [
             {
                 "index": 0,
@@ -75,18 +75,18 @@ class TestMaritacaClient:
         # Default initialization
         client = MaritacaClient(api_key=mock_api_key)
         assert client.api_key == mock_api_key
-        assert client.default_model == MaritacaModel.SABIA_3_1
+        assert client.default_model == MaritacaModel.SABIA_4
         assert client.timeout == 60
         assert client.max_retries == 3
 
         # Custom initialization
         custom_client = MaritacaClient(
             api_key=mock_api_key,
-            model=MaritacaModel.SABIA_3,
+            model=MaritacaModel.SABIAZINHO_4,
             timeout=30,
             max_retries=5,
         )
-        assert custom_client.default_model == MaritacaModel.SABIA_3
+        assert custom_client.default_model == MaritacaModel.SABIAZINHO_4
         assert custom_client.timeout == 30
         assert custom_client.max_retries == 5
 
@@ -113,7 +113,7 @@ class TestMaritacaClient:
                 response.content
                 == "Olá! Estou bem, obrigado por perguntar. Como posso ajudá-lo hoje?"
             )
-            assert response.model == "sabia-3"
+            assert response.model == "sabia-4"
             assert response.usage["total_tokens"] == 35
             assert response.finish_reason == "stop"
 
@@ -210,7 +210,7 @@ class TestMaritacaClient:
         with patch.object(maritaca_client, "chat_completion") as mock_completion:
             mock_completion.return_value = MaritacaResponse(
                 content="Olá",
-                model="sabia-3",
+                model="sabia-4",
                 usage={"total_tokens": 10},
                 metadata={},
                 response_time=0.5,
@@ -238,12 +238,12 @@ class TestMaritacaClient:
     def test_factory_function(self, mock_api_key):
         """Test factory function for client creation."""
         client = create_maritaca_client(
-            api_key=mock_api_key, model=MaritacaModel.SABIAZINHO_3, timeout=45
+            api_key=mock_api_key, model=MaritacaModel.SABIAZINHO_4, timeout=45
         )
 
         assert isinstance(client, MaritacaClient)
         assert client.api_key == mock_api_key
-        assert client.default_model == MaritacaModel.SABIAZINHO_3
+        assert client.default_model == MaritacaModel.SABIAZINHO_4
         assert client.timeout == 45
 
 


### PR DESCRIPTION
## Context

Maritaca retires `sabia-3` / `sabia-3.1` / `sabiazinho-3` on **2026-07-15**. This backend's **production default was still `sabia-3.1`**, so it would break. This PR migrates the default and every live code reference to `sabia-4` / `sabiazinho-4`.

## ⚠️ Production-affecting change — review before merge
- `src/core/config.py`: `llm_model_name` and `maritaca_model` defaults **`sabia-3.1` → `sabia-4`**. After merge+deploy, the default model served changes. Confirm `sabia-4` is the intended production default.

## Changes (19 files)
- **config**: both model defaults → `sabia-4`
- **maritaca_client**: `MaritacaModel` enum consolidated `SABIAZINHO_3`/`SABIA_3`/`SABIA_3_1` → `SABIAZINHO_4`/`SABIA_4`; all internal usages updated
- **services**: `chat_data_integration`, `dspy_agents` (DSPy LM), `maritaca_direct_service`; **agents**: `drummond`
- **routes/chat.py**: `list_maritaca_models` catalog (frontend selector) + response-example docstrings; fixed stale display name `Sabiá-3` → `Sabiá-4`
- **cost_tracker**: keys consolidated to `sabiazinho-4`/`sabia-4`
- **agents docs**: `santos_dumont`, `cidadao_ai_docs`
- **tests** (`test_maritaca_client`, abaporu×2, drummond×2) + **scripts** (debug×3, deployment×1)

## Verification
- Syntax-checked all 19 files; `grep` confirms **zero** live `sabia-3`/`sabiazinho-3` references (excluding `/archive/` and TODO comments)
- ⚠️ Backend `pytest` **not run locally** (deps unavailable in this env) — **relying on CI**. Please ensure the test job is green before merge.

## Follow-ups (not in this PR)
- `cost_tracker` pricing for `sabiazinho-4`/`sabia-4` carried over from old models — **confirm official Maritaca pricing**
- Backend **docs** (`docs/**/*.md`) still mention old models — cosmetic, pending
- `cidadao.ai-frontend` (model selector UI) + `cidadao.ai-technical-docs` — separate repos, separate migration
