### PR TITLE
fix(backend): repair pre-existing unit test failures (closes #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -470,3 +470,4 @@ coverage.xml
 dist/
 build/
 *.egg-info/
+.venv-ci/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Author**: Anderson Henrique da Silva
 **Location**: Minas Gerais, Brazil
 **Created**: 2025-08-13
-**Last Updated**: 2026-02-25
+**Last Updated**: 2026-06-30
 
 ---
 
@@ -11,6 +11,24 @@ All notable changes to the Cidadão.AI Backend project will be documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Fixed
+- **Agent lazy loader no longer deletes modules from `sys.modules` on unload** (`agent_lazy_loader.py`)
+  - `_unload_agent` removed the agent's module from `sys.modules`, so any later import re-executed it and produced duplicate class/function objects
+  - Broke `isinstance` checks, `unittest.mock` patches targeting the module, and module-level singletons (e.g. the transparency collector) after any agent unload
+  - Now only drops the class reference (`loaded_class = None`), which already releases memory
+  - Root cause of 10 ordering-dependent unit-test failures (Zumbi, Anita) that passed in isolation but failed once the agent pool triggered an unload
+- **Investigation execution crashed building `AgentContext`** (`investigation_service.py`)
+  - `data_sources` was passed as a constructor kwarg, but `AgentContext` has no such field, raising `TypeError` on every investigation
+  - Now passed through `AgentContext.metadata`
+- **`json_utils.dumps` rejected `sort_keys`** (`json_utils.py`)
+  - `cache_service` built deterministic cache keys with `sort_keys=True`, crashing the search-cache path
+  - Added `sort_keys` keyword (maps to `orjson.OPT_SORT_KEYS`)
+- **Realigned drifted unit tests with current code** — Anita spectral-analysis signature `(data, context)`, `test_verify_token_invalid` settings mock, and lazy-loader fixture isolation from default-agent preloading
 
 ---
 

--- a/src/core/json_utils.py
+++ b/src/core/json_utils.py
@@ -31,13 +31,14 @@ def default(obj: Any) -> Any:
     raise TypeError(f"Type {type(obj)} not serializable")
 
 
-def dumps(obj: Any, *, indent: bool = False) -> str:
+def dumps(obj: Any, *, indent: bool = False, sort_keys: bool = False) -> str:
     """
     Serialize obj to a JSON formatted string using orjson.
 
     Args:
         obj: Object to serialize
         indent: Whether to indent the output (slower but prettier)
+        sort_keys: Whether to sort object keys (recursive, deterministic output)
 
     Returns:
         JSON string
@@ -45,6 +46,8 @@ def dumps(obj: Any, *, indent: bool = False) -> str:
     options = orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
     if indent:
         options |= orjson.OPT_INDENT_2
+    if sort_keys:
+        options |= orjson.OPT_SORT_KEYS
 
     return orjson.dumps(obj, default=default, option=options).decode("utf-8")
 

--- a/src/services/agent_lazy_loader.py
+++ b/src/services/agent_lazy_loader.py
@@ -433,16 +433,16 @@ class AgentLazyLoader:
             )
             return
 
-        # Unload the module
+        # Unload the agent class
         try:
-            # Remove class reference
+            # Drop the loader's reference to the class so it can be garbage
+            # collected once no other references remain. We deliberately do NOT
+            # delete the module from sys.modules: re-importing it later would
+            # re-execute the module and create duplicate class/function objects,
+            # breaking isinstance checks, unittest.mock patches, and any cached
+            # module-level singletons (e.g. the transparency collector) without
+            # actually reclaiming meaningful memory.
             metadata.loaded_class = None
-
-            # Try to remove from sys.modules
-            import sys
-
-            if metadata.module_path in sys.modules:
-                del sys.modules[metadata.module_path]
 
             self._stats["total_unloads"] += 1
 

--- a/src/services/investigation_service.py
+++ b/src/services/investigation_service.py
@@ -121,7 +121,9 @@ class InvestigationService:
             context = AgentContext(
                 investigation_id=investigation.id,
                 user_id=investigation.user_id,
-                data_sources=investigation.metadata.get("data_sources", []),
+                metadata={
+                    "data_sources": investigation.metadata.get("data_sources", []),
+                },
             )
 
             # Execute with master agent

--- a/tests/unit/agents/test_anita_boost.py
+++ b/tests/unit/agents/test_anita_boost.py
@@ -267,15 +267,8 @@ class TestSpectralPatterns:
             )
 
         # Create request object required by method signature
-        request = AnalysisRequest(
-            query="test spectral patterns",
-            analysis_types=["spectral_patterns"],
-        )
-
         # Call method directly to ensure it's tested (lines 1087-1217)
-        patterns = await agent._analyze_spectral_patterns(
-            contracts, request, agent_context
-        )
+        patterns = await agent._analyze_spectral_patterns(contracts, agent_context)
 
         # Verify patterns were found (or method completed successfully)
         assert isinstance(patterns, list)
@@ -299,15 +292,8 @@ class TestSpectralPatterns:
             )
 
         # Create request object
-        request = AnalysisRequest(
-            query="test insufficient data",
-            analysis_types=["spectral_patterns"],
-        )
-
         # Call method directly to test insufficient data handling
-        patterns = await agent._analyze_spectral_patterns(
-            contracts, request, agent_context
-        )
+        patterns = await agent._analyze_spectral_patterns(contracts, agent_context)
 
         # Should return empty list (insufficient data - only 10 contracts < 30 minimum)
         assert isinstance(patterns, list)
@@ -336,15 +322,8 @@ class TestSpectralPatterns:
                 )
 
         # Create request object
-        request = AnalysisRequest(
-            query="test multiple orgs",
-            analysis_types=["spectral_patterns"],
-        )
-
         # Call method directly to ensure it's tested
-        patterns = await agent._analyze_spectral_patterns(
-            contracts, request, agent_context
-        )
+        patterns = await agent._analyze_spectral_patterns(contracts, agent_context)
 
         # Should process multiple organizations and find patterns
         assert isinstance(patterns, list)
@@ -384,15 +363,8 @@ class TestSpectralPatterns:
             )
 
         # Create request object
-        request = AnalysisRequest(
-            query="test strong periodicity",
-            analysis_types=["spectral_patterns"],
-        )
-
         # Call method to test lines 1125-1166 (PatternResult creation for strong patterns)
-        patterns = await agent._analyze_spectral_patterns(
-            contracts, request, agent_context
-        )
+        patterns = await agent._analyze_spectral_patterns(contracts, agent_context)
 
         # Should return patterns (may be empty if amplitude threshold not met, but method executes)
         assert isinstance(patterns, list)
@@ -427,15 +399,8 @@ class TestSpectralPatterns:
             )
 
         # Create request object
-        request = AnalysisRequest(
-            query="test regular data",
-            analysis_types=["spectral_patterns"],
-        )
-
         # Call method to test lines 1172-1206 (PatternResult creation for low entropy)
-        patterns = await agent._analyze_spectral_patterns(
-            contracts, request, agent_context
-        )
+        patterns = await agent._analyze_spectral_patterns(contracts, agent_context)
 
         # Should return patterns (may be empty if entropy threshold not met, but method executes)
         assert isinstance(patterns, list)
@@ -492,15 +457,8 @@ class TestSpectralPatterns:
                 return_value=mock_features,
             ),
         ):
-            request = AnalysisRequest(
-                query="test high amplitude",
-                analysis_types=["spectral_patterns"],
-            )
-
             # This should execute lines 1125-1166 (PatternResult creation for high amplitude)
-            patterns = await agent._analyze_spectral_patterns(
-                contracts, request, agent_context
-            )
+            patterns = await agent._analyze_spectral_patterns(contracts, agent_context)
 
             # Should create PatternResult objects for high amplitude patterns
             assert isinstance(patterns, list)

--- a/tests/unit/services/test_auth_service.py
+++ b/tests/unit/services/test_auth_service.py
@@ -367,8 +367,11 @@ class TestTokenVerification:
     @pytest.mark.asyncio
     async def test_verify_token_invalid(self, service):
         """Test verifying invalid token."""
-        with pytest.raises(AuthenticationError, match="Invalid token"):
-            await service.verify_token("invalid.token.here")
+        with patch("src.services.auth_service.settings") as mock_settings:
+            mock_settings.JWT_SECRET_KEY = "test-secret-key"
+
+            with pytest.raises(AuthenticationError, match="Invalid token"):
+                await service.verify_token("invalid.token.here")
 
 
 class TestTokenBlacklist:

--- a/tests/unit/test_agent_lazy_loader.py
+++ b/tests/unit/test_agent_lazy_loader.py
@@ -41,6 +41,18 @@ class TestAgentLazyLoader:
         """Create a lazy loader instance."""
         loader = AgentLazyLoader(unload_after_minutes=1, max_loaded_agents=3)
         await loader.start()
+        # Isolate each test from the default agents preloaded by start():
+        # keep the registry intact (available-agents tests rely on it) but drop
+        # the preloaded classes and reset the load/unload counters to zero.
+        for metadata in loader._registry.values():
+            metadata.loaded_class = None
+        loader._stats = {
+            "total_loads": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "total_unloads": 0,
+            "avg_load_time_ms": 0.0,
+        }
         yield loader
         await loader.stop()
 


### PR DESCRIPTION
## Summary

Repairs the pre-existing unit-test failures flagged by CI so the suite gates on a clean baseline. Closes #20.

Reproduced the 23 CI failures locally on Python 3.11 and split them into two real code bugs and three test-drift corrections.

### Code fixes (production bugs)
- **investigation_service**: `data_sources` is now passed through `AgentContext.metadata`. `AgentContext` has no `data_sources` field, so the kwarg raised `TypeError` whenever an investigation executed.
- **json_utils.dumps**: added `sort_keys` (maps to `orjson.OPT_SORT_KEYS`). `cache_service.cache_search_results` builds deterministic cache keys with `sort_keys=True` and was crashing on every call.

### Test-drift corrections
- **test_anita_boost**: `_analyze_spectral_patterns` takes `(data, context)`; dropped the stale `request` argument from the 6 spectral calls and removed the now-dead `request` fixtures.
- **test_auth_service**: `test_verify_token_invalid` now mocks `settings` exactly like its sibling tests, so it uses the test secret key instead of the real `Settings` object (which has no `JWT_SECRET_KEY`).
- **test_agent_lazy_loader**: the fixture now isolates each test from default-agent preloading by resetting load stats and dropping preloaded classes.

## Validation
- All affected test files pass together: **217 passed** (Python 3.11).
- `json_utils.dumps` change is purely additive (new keyword-only arg), so existing callers are unaffected.
- Full-suite confirmation left to CI (local env lacks the DB/Redis/network services that several agent integration-style tests require).