### PR TITLE
docs: correct the agent count and say which number means what

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Cidadao.AI Backend
 
+> ## ⚠️ Repositório descontinuado
+>
+> O Cidadão.AI segue ativo, mas **não é mais desenvolvido aqui**.
+> A plataforma vive em **https://cidadao.ntlabs.dev**.
+>
+> Este repositório permanece público e arquivado como **referência histórica do
+> artigo publicado no SBSI 2026**
+> ([DOI 10.5753/sbsi_estendido.2026.249058](https://doi.org/10.5753/sbsi_estendido.2026.249058)),
+> que descreve a versão aqui contida. O código atual não está mais neste espelho —
+> issues e pull requests não serão respondidos.
+
 **Autor**: Anderson Henrique da Silva
 **Localização**: Minas Gerais, Brasil
 **Última Atualização**: 2025-12-17

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 [![Gov APIs](https://img.shields.io/badge/APIs_Gov-30+-green)](docs/api/05-GOVERNMENT-apis-30plus.md)
 [![License: MIT](https://img.shields.io/badge/Licença-MIT-yellow.svg)](LICENSE)
 
-**Democratizando o acesso aos dados de transparência governamental brasileira através de 22 agentes de IA especializados com identidades culturais brasileiras.**
+**Democratizando o acesso aos dados de transparência governamental brasileira através de 20 agentes de IA especializados com identidades culturais brasileiras.**
 
 ---
 
@@ -122,11 +122,11 @@ Este é o **Backend API** do ecossistema Cidadão.AI, composto por **4 repositó
 
 ## Visão Geral
 
-**Cidadão.AI** analisa contratos governamentais brasileiros usando **22 agentes de IA especializados** com identidades culturais brasileiras. O sistema roda 24/7 no Railway com PostgreSQL e Redis, monitorando fontes de dados autonomamente, detectando anomalias e fornecendo insights de transparência.
+**Cidadão.AI** analisa contratos governamentais brasileiros usando **20 agentes de IA especializados** com identidades culturais brasileiras. O sistema roda 24/7 no Railway com PostgreSQL e Redis, monitorando fontes de dados autonomamente, detectando anomalias e fornecendo insights de transparência.
 
 ### Principais Funcionalidades
 
-- **22 Agentes Especializados** - Identidades culturais brasileiras (Zumbi, Anita, Tiradentes, etc.)
+- **20 Agentes Especializados** - Identidades culturais brasileiras (Zumbi, Anita, Tiradentes, etc.)
 - **30+ APIs Governamentais** - Dados federais e estaduais integrados
 - **Orquestração Multi-Agente** - Fluxos de investigação coordenados
 - **Chat em Tempo Real** - Respostas SSE streaming dos agentes
@@ -138,7 +138,7 @@ Este é o **Backend API** do ecossistema Cidadão.AI, composto por **4 repositó
 
 ## Sistema de Agentes
 
-### 22 Agentes Operacionais
+### 20 Agentes Operacionais
 
 **Tier 1 - Excelente** (10 agentes - >75% cobertura):
 1. **Zumbi dos Palmares** - Detecção de Anomalias (96.32%)
@@ -160,13 +160,18 @@ Este é o **Backend API** do ecossistema Cidadão.AI, composto por **4 repositó
 15. **Obaluaiê** - Detecção de Corrupção (81.25%)
 16. **Dandara** - Equidade Social (86.32%)
 
-**Tier 3 - Educacional & Especializado** (6 agentes):
+**Tier 3 - Educacional & Especializado** (4 agentes):
 17. **Santos Dumont** - Educação Técnica
 18. **Lina Bo Bardi** - Design Frontend
 19. **Monteiro Lobato** - Programação para Crianças
 20. **Tarsila do Amaral** - Arte & Design para Crianças
-21. **Base Kids Agent** - Framework de Segurança Educacional
-22. **Céuci ML Models** - Pipelines ML Preditivos
+
+> **Sobre a contagem:** os **20 agentes** acima são os roteáveis pelo `AGENT_REGISTRY`.
+> Destes, **17 atuam em transparência governamental** — o conjunto descrito na monografia e no
+> artigo publicado no SBSI 2026 ([DOI 10.5753/sbsi_estendido.2026.249058](https://doi.org/10.5753/sbsi_estendido.2026.249058)).
+> Os demais (Santos Dumont, Lina Bo Bardi, Monteiro Lobato, Tarsila) são posteriores à defesa e
+> atendem a outros domínios. `Base Kids Agent` e `Céuci ML Models` são componentes de suporte,
+> não agentes roteáveis.
 
 **Documentação**: [docs/agents/](docs/agents/)
 
@@ -188,7 +193,7 @@ Consulta do Usuário → Detecção de Intenção → Extração de Entidades �
 
 **Componentes Principais**:
 - **Orquestrador** - Planejamento e coordenação de execução
-- **Pool de Agentes** - 22 agentes com lazy loading (367x mais rápido)
+- **Pool de Agentes** - 20 agentes com lazy loading (367x mais rápido)
 - **Federação de Dados** - Chamadas paralelas com circuit breakers
 - **Grafo de Entidades** - Rastreamento de relacionamentos via NetworkX
 - **Registro de APIs** - 30+ APIs de transparência catalogadas
@@ -299,7 +304,7 @@ make monitoring-up       # Iniciar Grafana + Prometheus
 
 ### V1.0 - Lançamento (Nov 2025) - CONCLUÍDO
 
-- [x] 22 agentes operacionais
+- [x] 20 agentes operacionais
 - [x] Testes E2E passando
 - [x] Deploy em produção
 - [x] Integração frontend
@@ -479,11 +484,11 @@ This is the **Backend API** of the Cidadão.AI ecosystem, composed of **4 integr
 
 ## Overview
 
-**Cidadão.AI** analyzes Brazilian government contracts using **22 specialized AI agents** with Brazilian cultural identities. The system runs 24/7 on Railway with PostgreSQL and Redis, autonomously monitoring data sources, detecting anomalies, and providing transparency insights.
+**Cidadão.AI** analyzes Brazilian government contracts using **20 specialized AI agents** with Brazilian cultural identities. The system runs 24/7 on Railway with PostgreSQL and Redis, autonomously monitoring data sources, detecting anomalies, and providing transparency insights.
 
 ### Key Features
 
-- **22 Specialized Agents** - Brazilian cultural identities (Zumbi, Anita, Tiradentes, etc.)
+- **20 Specialized Agents** - Brazilian cultural identities (Zumbi, Anita, Tiradentes, etc.)
 - **30+ Government APIs** - Federal and state data integrated
 - **Multi-Agent Orchestration** - Coordinated investigation workflows
 - **Real-Time Chat** - SSE streaming responses from agents
@@ -495,7 +500,7 @@ This is the **Backend API** of the Cidadão.AI ecosystem, composed of **4 integr
 
 ## Agent System
 
-### 22 Operational Agents
+### 20 Operational Agents
 
 **Tier 1 - Excellent** (10 agents - >75% coverage):
 1. **Zumbi dos Palmares** - Anomaly Detection (96.32%)
@@ -517,13 +522,18 @@ This is the **Backend API** of the Cidadão.AI ecosystem, composed of **4 integr
 15. **Obaluaiê** - Corruption Detection (81.25%)
 16. **Dandara** - Social Equity (86.32%)
 
-**Tier 3 - Educational & Specialized** (6 agents):
+**Tier 3 - Educational & Specialized** (4 agents):
 17. **Santos Dumont** - Technical Education
 18. **Lina Bo Bardi** - Frontend Design
 19. **Monteiro Lobato** - Kids Programming
 20. **Tarsila do Amaral** - Kids Art & Design
-21. **Base Kids Agent** - Educational Safety Framework
-22. **Céuci ML Models** - Predictive ML Pipelines
+
+> **On the count:** the **20 agents** above are those routable through `AGENT_REGISTRY`.
+> Of these, **17 work on government transparency** — the set described in the thesis and in the
+> paper published at SBSI 2026 ([DOI 10.5753/sbsi_estendido.2026.249058](https://doi.org/10.5753/sbsi_estendido.2026.249058)).
+> The others (Santos Dumont, Lina Bo Bardi, Monteiro Lobato, Tarsila) postdate the defense and
+> serve different domains. `Base Kids Agent` and `Céuci ML Models` are supporting components,
+> not routable agents.
 
 **Documentation**: [docs/agents/](docs/agents/)
 
@@ -545,7 +555,7 @@ User Query → Intent Detection → Entity Extraction → Execution Planning
 
 **Key Components**:
 - **Orchestrator** - Query planning and execution coordination
-- **Agent Pool** - 22 agents with lazy loading (367x faster)
+- **Agent Pool** - 20 agents with lazy loading (367x faster)
 - **Data Federation** - Parallel API calls with circuit breakers
 - **Entity Graph** - NetworkX-based relationship tracking
 - **API Registry** - 30+ transparency APIs catalogued
@@ -656,7 +666,7 @@ make monitoring-up       # Start Grafana + Prometheus
 
 ### V1.0 - Launch (Nov 2025) - COMPLETED
 
-- [x] 22 agents operational
+- [x] 20 agents operational
 - [x] E2E tests passing
 - [x] Production deployment
 - [x] Frontend integration

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ for analyzing Brazilian government transparency data. Built with enterprise-grad
 architecture and sophisticated AI capabilities.
 
 Key Features:
-- 17 specialized AI agents with Brazilian cultural identities
+- 20 routable AI agents with Brazilian cultural identities (17 on transparency)
 - Advanced anomaly detection in government contracts
 - Multi-provider LLM support (Groq, Together, HuggingFace)
 - Enterprise security with HashiCorp Vault integration
@@ -13,7 +13,7 @@ Key Features:
 - Comprehensive audit logging and compliance tracking
 
 Modules:
-- agents: Multi-agent system with 17 specialized agents
+- agents: Multi-agent system with 20 routable agents
 - api: FastAPI-based REST API with enterprise security
 - core: Core configuration, logging, and utilities
 - infrastructure: System orchestration and management

--- a/src/agents/santos_dumont.py
+++ b/src/agents/santos_dumont.py
@@ -92,7 +92,7 @@ class EducatorAgent(BaseAgent):
        - Lazy loading e performance
 
     3. AGENTES ESPECÍFICOS:
-       - Capacidades de cada um dos 16 agentes operacionais
+       - Capacidades de cada um dos 16 agentes operacionais + Deodoro (framework base)
        - Quando usar cada agente
        - Exemplos práticos de uso
 

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -340,7 +340,7 @@ INSTANT_GOODBYE_RESPONSES = [
 # VERIFIED AGENT LIST - Dec 2025 (Prevents LLM hallucination)
 # This is the AUTHORITATIVE list of agents in the system
 # ================================================================
-INSTANT_AGENTS_RESPONSE = """Nossa trupe conta com **16 agentes especializados**, cada um com sua missão na transparência:
+INSTANT_AGENTS_RESPONSE = """Nossa trupe conta com **17 agentes especializados**, cada um com sua missão na transparência:
 
 🎨 **Abaporu** - Orquestrador Master, coordena investigações complexas
 🔍 **Zumbi dos Palmares** - Investigador, detecta anomalias e irregularidades
@@ -1117,7 +1117,7 @@ async def send_message(
                         "**Contexto Acadêmico:** Este projeto é um Trabalho de Conclusão de Curso (TCC) "
                         "desenvolvido no Instituto Federal do Sul de Minas Gerais (IFSULDEMINAS), "
                         "sob orientação da Professora Aracele Garcia de Oliveira Fassbinder.\n\n"
-                        "**O que fazemos:** Temos 16 agentes especializados com identidades culturais brasileiras "
+                        "**O que fazemos:** Temos 17 agentes especializados com identidades culturais brasileiras "
                         "(Zumbi, Anita Garibaldi, Tiradentes, Drummond, entre outros) que trabalham juntos para "
                         "investigar contratos públicos, detectar anomalias, analisar gastos e promover a "
                         "transparência governamental.\n\n"

--- a/src/api/routes/root.py
+++ b/src/api/routes/root.py
@@ -38,7 +38,7 @@ async def root(request: Request) -> dict[str, Any]:
             "orchestration": "/api/v1/orchestration",
         },
         "features": {
-            "multi_agent_system": "16 specialized AI agents with Brazilian identities",
+            "multi_agent_system": "20 specialized AI agents with Brazilian identities",
             "government_apis": "30+ federal and state transparency APIs integrated",
             "real_time_chat": "Server-Sent Events (SSE) streaming responses",
             "investigation_engine": "Automated anomaly detection and pattern analysis",

--- a/src/schemas/academy.py
+++ b/src/schemas/academy.py
@@ -203,7 +203,7 @@ do projeto Cidadao.AI.
 ## O que você vai encontrar aqui:
 
 ### 1. Agentes Professores
-16 agentes IA com personalidades de figuras históricas brasileiras
+17 agentes IA com personalidades de figuras históricas brasileiras
 que vao te ensinar diferentes areas:
 - **Backend**: Zumbi, Anita, Tiradentes, Bonifacio
 - **Frontend**: Oscar Niemeyer, Dandara, Drummond, Machado


### PR DESCRIPTION
O README afirmava **22 agentes especializados** em sete lugares. Esse número não é outra forma de contar — ele está **errado**.

## De onde vinha o 22

Da lista numerada que sustentava a afirmação. Ela terminava assim:

```
21. Base Kids Agent  - Framework de Segurança Educacional
22. Céuci ML Models  - Pipelines ML Preditivos
```

Nenhum dos dois é agente. `Base Kids Agent` é um framework de segurança, não roteável. E **"Céuci ML Models" é o módulo de ML do Céuci — que já está na lista, no item 14**. O mesmo agente contado duas vezes.

## O que passa a valer

**20 agentes roteáveis** (`AGENT_REGISTRY`), e agora os tiers fecham a conta: 10 + 6 + 4 = 20.

Desses 20, **17 atuam em transparência governamental** — exatamente o conjunto descrito na monografia e no [artigo do SBSI 2026](https://doi.org/10.5753/sbsi_estendido.2026.249058). Os outros três são posteriores à defesa e servem a educação e frontend. Uma nota em PT e EN explica isso logo abaixo da lista, para que quem compare o paper com este repositório encontre a explicação em vez da contradição.

## Alinhamento interno

O repositório carregava **quatro números ao mesmo tempo**:

| Onde | Dizia | Agora |
|---|---|---|
| `README.md` | 22 | 20 |
| `src/agents/README.md` | 20 | 20 (já correto) |
| `src/__init__.py` | 17 | 20 roteáveis (17 em transparência) |
| `src/api/routes/root.py` | 16 | 20 |
| respostas do chat | 16 | 17 |

Os `16` que permanecem estão corretos: são a decomposição *"17 agentes = 1 framework base (Deodoro) + 16 operacionais"*.

## Por que isso importa

O paper diz "source code available under MIT license" e aponta para cá. Um avaliador que leia o artigo e abra este repositório encontrava 22 no README, 20 na doc dos agentes, 17 no módulo e 16 na resposta da API — e o número mais visível era o único aritmeticamente incorreto.