### PR TITLE
fix(agents): use the offset aliases pandas 3 still accepts

### DIFF
--- a/src/agents/ceuci_ml_models.py
+++ b/src/agents/ceuci_ml_models.py
@@ -356,7 +356,7 @@ class ProphetModel:
             elif time_diff.days >= 7:  # Weekly
                 self.freq = "W"
             elif time_diff.hours >= 1:  # Hourly
-                self.freq = "H"
+                self.freq = "h"
             else:  # Daily
                 self.freq = "D"
 

--- a/src/agents/oxossi.py
+++ b/src/agents/oxossi.py
@@ -539,7 +539,7 @@ class OxossiAgent(BaseAgent):
             df = df.sort_values("date")
 
             # Group by time periods and check for uniform increases
-            monthly_avg = df.groupby(pd.Grouper(key="date", freq="M"))["price"].mean()
+            monthly_avg = df.groupby(pd.Grouper(key="date", freq="ME"))["price"].mean()
             if len(monthly_avg) > 3:
                 price_changes = monthly_avg.pct_change().dropna()
                 if (price_changes > 0.05).sum() > 1:  # Multiple 5%+ increases

--- a/tests/unit/agents/test_ceuci.py
+++ b/tests/unit/agents/test_ceuci.py
@@ -39,7 +39,7 @@ def ceuci_agent():
 @pytest.fixture
 def sample_time_series_data():
     """Create sample time series data for testing."""
-    dates = pd.date_range(start="2024-01-01", periods=24, freq="M")
+    dates = pd.date_range(start="2024-01-01", periods=24, freq="ME")
     values = [100 + i * 5 + np.random.normal(0, 10) for i in range(24)]  # Trend + noise
     return pd.DataFrame({"date": dates, "value": values})
 
@@ -560,7 +560,7 @@ class TestCeuciPrivateMethods:
         """Test trend analysis."""
         data = pd.DataFrame(
             {
-                "date": pd.date_range("2024-01-01", periods=24, freq="M"),
+                "date": pd.date_range("2024-01-01", periods=24, freq="ME"),
                 "value": [100 + i * 5 for i in range(24)],
             }
         )


### PR DESCRIPTION
Six unit tests fail in CI with `ValueError: 'M' is no longer supported for
offsets. Please use 'ME' instead.` They are a regression: after #21 the suite
was `2198 passed, 0 failed`.

## Root cause

`pandas` is declared as `pandas>=2.1.4` in both `pyproject.toml` and
`requirements.txt`, **with no upper bound**. CI resolves pandas 3.x, where the
single-letter offset aliases were removed. The local `.venv-ci` has 2.3.3, where
the same aliases are merely deprecated and only emit a `FutureWarning`.

**This is why the failure is invisible locally.** Running the two affected files
here gives `97 passed` with or without this change. The positive control makes it
explicit: on 2.3.3, `pd.date_range(..., freq='M')` does not raise, it warns. The
local green proves no regression, not the repair. CI on pandas 3.x is the real
check for this PR.

## Change

| File | Was | Is |
|---|---|---|
| `src/agents/oxossi.py:542` | `freq="M"` | `freq="ME"` |
| `src/agents/ceuci_ml_models.py:359` | `self.freq = "H"` | `self.freq = "h"` |
| `tests/unit/agents/test_ceuci.py` (3 spots) | `freq="M"` | `freq="ME"` |

Both new spellings are accepted from pandas 2.2 upward, so no version bump is
needed and the change is safe on the older local resolution too.

## Not fixed here, and worth its own issue

`src/agents/ceuci_ml_models.py:359` sits in a branch guarded by
`time_diff.hours`. `pd.Timedelta` has no `.hours` attribute (it has
`.components.hours`), so that branch raises `AttributeError` before it ever
reaches the frequency assignment. The `H` → `h` correction there is therefore
unreachable until that guard is fixed. It changes behaviour, so it does not
belong in a deprecation cleanup.

## Note on the remaining red

The coverage gate (43.22% against a 60% threshold) is a long-standing
configuration issue on `main`, unrelated to this change and to test correctness.
It will keep this PR's `Tests & Code Quality` job red even once the six failures
are gone.

https://claude.ai/code/session_011fgxBLYHVbWQuaoqcJdFq1