### PR TITLE
chore(ci): make the coverage gate a ratchet, and stop the suite crawling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov ruff black isort mypy
+          pip install pytest pytest-asyncio pytest-cov pytest-xdist ruff black isort mypy
 
       - name: Code formatting check (Black)
         run: black --check src tests
@@ -52,7 +52,7 @@ jobs:
           ANTHROPIC_API_KEY: test-anthropic-key
           TRANSPARENCY_API_KEY: ${{ secrets.TRANSPARENCY_API_KEY }}
         run: |
-          pytest tests/unit -v --cov=src --cov-report=xml --cov-report=term-missing --cov-report=html --tb=short --cov-fail-under=60
+          pytest tests/unit -v -n auto --cov=src --cov-report=xml --cov-report=term-missing --tb=short --cov-fail-under=43
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Why

`CI Pipeline` has been red on every commit for months, and not because of tests. The gate asks for 60% while unit-only coverage of `src/` measures **43.17%**. That 60% was calibrated against the *full* suite (integration and e2e included), so `pytest tests/unit` could never reach it. A build that always fails carries no information, and today it hid two real regressions until they were dug out by hand.

## What changes

- **Floor at the measured value (43).** The gate now blocks *regressions* rather than blocking everything. The number rises with each batch of new tests, on the way to 70%.
- **`-n auto` via pytest-xdist**, added to the CI install list (it was already a dev dependency in `pyproject.toml`, just never installed in CI). The job took **24m47s** running ~2200 tests serially, while every other job in the pipeline finishes in about two minutes.
- **Dropped `--cov-report=html`.** No step uploads it, so it was written and thrown away.

## Risk

`-n auto` is the real risk here: tests that share state or a fixture file can fail when distributed across workers. This PR's own run is the experiment. If workers cause failures, the fix is `--dist loadfile` rather than reverting the parallelism.

## Not in this PR

Raising coverage itself. The map, by uncovered statements: `api/routes/chat.py` (644), `llm/providers.py` (344, at 0%), `infrastructure/orchestrator.py` (408, at 0%, imported by 10 modules), `api/middleware/security.py` (252, at 0%). Worth noting that `src/agents/` already sits at **85.3%** — the product core is covered; infrastructure, ML and CLI are what drag the average down.

Claude-Session: https://claude.ai/code/session_015bgSy5JxseiACEYDL9Wk4z