### PR TITLE
Cover the security middleware and the LLM fallback chain (and fix three defects they exposed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Author**: Anderson Henrique da Silva
 **Location**: Minas Gerais, Brazil
 **Created**: 2025-08-13
-**Last Updated**: 2026-08-12
+**Last Updated**: 2026-09-06
 
 ---
 
@@ -17,9 +17,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Unit tests for the security middleware** (`tests/unit/middleware/test_security.py`, 81 tests)
+  - `src/api/middleware/security.py` had zero coverage: 254 statements of IP blocking, rate limiting, request scanning and CSRF with no test at all
+  - Tests concentrate on the deny paths — blocked IP (403), exhausted rate limit (429 with `Retry-After`), oversized body (413), suspicious header/URL (400), unsupported content type (415) — and assert that the downstream app is never reached
+  - Coverage of the module went from 0% to 96%
+
+- **Unit tests for the LLM provider fallback chain** (`tests/unit/llm/test_providers.py`, 70 tests)
+  - `src/llm/providers.py` had zero coverage despite being the single path every agent takes to reach a model
+  - Tests assert *which* providers were contacted, not only the returned value, so a chain that silently stops early fails the test
+  - Covers retry/backoff on 429, 5xx and timeout; pool degradation to the direct client; the dummy-key path when `MARITACA_API_KEY` is unset
+  - Coverage of the module went from 0% to 89%
+
 - **Regression tests for the mounted GraphQL router** (`tests/unit/api/test_graphql.py::TestGraphQLRouterMounted`)
   - The pre-existing GraphQL tests assert `status_code in [200, 400, 503]`, and 503 is the stub router's own "GraphQL not available" status — they tolerate the outage by design and cannot be the guard
   - The new tests assert that `src.api.graphql.schema` imports, that `GraphQLRouter` (not the stub) is mounted, that `POST /graphql` returns exactly 200, and that a swallowed import failure still reaches the log
+
+### Fixed
+- **URL-encoded payloads no longer bypass the request scanner** (`src/api/middleware/security.py`)
+  - Every suspicious pattern that relies on `\s` (`union select`, `drop table`, `insert into`, `delete from`, ...) was matched against the raw query string, where a space is `+` or `%20`
+  - `?id=1+union+select+password+from+users` therefore passed the scanner untouched, while the same payload with literal spaces was blocked
+  - The validator now also scans the `unquote_plus`-decoded path and query
+
+- **The LLM fallback chain no longer collapses when the primary is also a fallback** (`src/llm/providers.py`)
+  - The loop ended on `provider == providers_to_try[-1]`, a value comparison. With Maritaca as primary — the documented production setting — the default fallback list `[together, huggingface, maritaca]` made the first element equal to the last, so a Maritaca outage broke out of the loop immediately and raised "All LLM providers failed" without ever contacting a fallback
+  - `_build_provider_chain` now de-duplicates the chain and the loop ends on the index, so no provider is tried twice and the last one is identified positionally
+
+- **`LLMRateLimitError` is no longer downgraded to a generic `LLMError`** (`src/llm/providers.py`)
+  - `_handle_error_response` classified a 429 correctly, but the broad `except Exception` in `_non_stream_request`/`_stream_request` caught it and re-raised it as `LLMError("Unexpected error: Rate limit exceeded")`
+  - Callers could not distinguish a quota exhaustion that should be retried later from a permanent failure. `LLMError` subclasses are now re-raised unchanged
 
 ### Security
 - **Rotated every credential exposed in the public git history** — PostgreSQL, Redis, Grafana Cloud and Portal da Transparência keys were replaced; the leaked values are now rejected by their services

--- a/src/api/middleware/security.py
+++ b/src/api/middleware/security.py
@@ -13,6 +13,7 @@ import re
 import time
 from collections import defaultdict, deque
 from datetime import UTC, datetime, timedelta
+from urllib.parse import unquote_plus
 
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
@@ -359,9 +360,12 @@ class RequestValidator:
 
         # Check if path is exempt from pattern checking
         if request.url.path not in SecurityConfig.PATTERN_CHECK_EXEMPT_PATHS:
-            # Check for suspicious patterns in path and query only
+            # Percent- and plus-encoded spaces would otherwise defeat every
+            # pattern that relies on \s ("union select", "drop table", ...),
+            # so scan the decoded form as well as the raw one.
+            decoded = unquote_plus(path_and_query)
             for pattern in self.suspicious_patterns:
-                if pattern.search(path_and_query):
+                if pattern.search(path_and_query) or pattern.search(decoded):
                     return False, "Suspicious pattern in URL"
 
         # Check for double encoding

--- a/src/llm/providers.py
+++ b/src/llm/providers.py
@@ -227,6 +227,12 @@ class BaseLLMProvider(ABC):
                     details={"provider": self.__class__.__name__},
                 )
 
+            except LLMError:
+                # Already classified by _handle_error_response (rate limit,
+                # upstream status). Re-wrapping it here would erase the type
+                # the caller needs to decide between backing off and failing.
+                raise
+
             except Exception as e:
                 self.logger.error(
                     "llm_request_error",
@@ -300,6 +306,10 @@ class BaseLLMProvider(ABC):
                     f"Stream request timeout after {self.timeout} seconds",
                     details={"provider": self.__class__.__name__},
                 )
+
+            except LLMError:
+                # Keep the classified error type (see _non_stream_request).
+                raise
 
             except Exception as e:
                 self.logger.error(
@@ -790,6 +800,24 @@ class LLMManager:
             enable_fallback=enable_fallback,
         )
 
+    def _build_provider_chain(self) -> list[LLMProvider]:
+        """
+        Build the ordered list of providers to try.
+
+        The primary provider may also appear in the fallback list (the default
+        fallback list contains Maritaca, which is the configured primary in
+        production). Duplicates are dropped so a failing primary does not
+        short-circuit the whole chain and is not contacted twice.
+        """
+        chain = [self.primary_provider]
+
+        if self.enable_fallback:
+            for provider in self.fallback_providers:
+                if provider not in chain:
+                    chain.append(provider)
+
+        return chain
+
     async def complete(self, request: LLMRequest) -> LLMResponse:
         """
         Complete text generation with fallback support.
@@ -800,13 +828,11 @@ class LLMManager:
         Returns:
             LLM response
         """
-        providers_to_try = [self.primary_provider]
-        if self.enable_fallback:
-            providers_to_try.extend(self.fallback_providers)
+        providers_to_try = self._build_provider_chain()
 
         last_error = None
 
-        for provider in providers_to_try:
+        for index, provider in enumerate(providers_to_try):
             try:
                 self.logger.info(
                     "llm_completion_attempt",
@@ -835,7 +861,7 @@ class LLMManager:
                     fallback_available=len(providers_to_try) > 1,
                 )
 
-                if not self.enable_fallback or provider == providers_to_try[-1]:
+                if not self.enable_fallback or index == len(providers_to_try) - 1:
                     break
 
                 continue
@@ -862,13 +888,11 @@ class LLMManager:
         Yields:
             Text chunks
         """
-        providers_to_try = [self.primary_provider]
-        if self.enable_fallback:
-            providers_to_try.extend(self.fallback_providers)
+        providers_to_try = self._build_provider_chain()
 
         last_error = None
 
-        for provider in providers_to_try:
+        for index, provider in enumerate(providers_to_try):
             try:
                 self.logger.info(
                     "llm_stream_attempt",
@@ -890,7 +914,7 @@ class LLMManager:
                     fallback_available=len(providers_to_try) > 1,
                 )
 
-                if not self.enable_fallback or provider == providers_to_try[-1]:
+                if not self.enable_fallback or index == len(providers_to_try) - 1:
                     break
 
                 continue

--- a/tests/unit/llm/test_providers.py
+++ b/tests/unit/llm/test_providers.py
@@ -115,6 +115,7 @@ def no_sleep():
 
 
 class TestLLMManagerCompletionFallback:
+    @pytest.mark.asyncio
     async def test_primary_success_never_touches_the_fallbacks(self, request_obj):
         primary = RecordingProvider("groq")
         fallback = RecordingProvider("maritaca")
@@ -130,6 +131,7 @@ class TestLLMManagerCompletionFallback:
         assert primary.complete_calls == 1
         assert fallback.complete_calls == 0
 
+    @pytest.mark.asyncio
     async def test_primary_failure_is_served_by_the_next_provider(self, request_obj):
         primary = RecordingProvider("groq", error=LLMError("groq is down"))
         fallback = RecordingProvider("maritaca")
@@ -145,6 +147,7 @@ class TestLLMManagerCompletionFallback:
         assert primary.complete_calls == 1, "the primary must have been tried first"
         assert fallback.complete_calls == 1
 
+    @pytest.mark.asyncio
     async def test_maritaca_primary_still_falls_back_with_the_default_chain(
         self, request_obj
     ):
@@ -170,6 +173,7 @@ class TestLLMManagerCompletionFallback:
         assert maritaca.complete_calls == 1
         assert together.complete_calls == 1
 
+    @pytest.mark.asyncio
     async def test_a_provider_is_never_retried_twice_in_one_chain(self, request_obj):
         maritaca = RecordingProvider("maritaca", error=LLMError("down"))
         together = RecordingProvider("together", error=LLMError("down"))
@@ -189,6 +193,7 @@ class TestLLMManagerCompletionFallback:
 
         assert maritaca.complete_calls == 1, "duplicated provider must not be re-tried"
 
+    @pytest.mark.asyncio
     async def test_fallback_order_is_respected(self, request_obj):
         first = RecordingProvider("together", error=LLMError("down"))
         second = RecordingProvider("huggingface")
@@ -208,6 +213,7 @@ class TestLLMManagerCompletionFallback:
         assert response.provider == "huggingface"
         assert first.complete_calls == 1
 
+    @pytest.mark.asyncio
     async def test_all_providers_down_raises_instead_of_returning_empty(
         self, request_obj
     ):
@@ -231,6 +237,7 @@ class TestLLMManagerCompletionFallback:
         assert exc_info.value.details == {"provider": "all"}
         assert fallback.complete_calls == 1
 
+    @pytest.mark.asyncio
     async def test_fallback_disabled_means_the_backup_is_never_contacted(
         self, request_obj
     ):
@@ -249,6 +256,7 @@ class TestLLMManagerCompletionFallback:
         assert fallback.complete_calls == 0
         assert fallback.enter_calls == 0
 
+    @pytest.mark.asyncio
     async def test_context_manager_is_exited_even_when_the_provider_fails(
         self, request_obj
     ):
@@ -265,6 +273,7 @@ class TestLLMManagerCompletionFallback:
         assert primary.enter_calls == 1
         assert primary.exit_calls == 1, "a failed provider must still be closed"
 
+    @pytest.mark.asyncio
     async def test_a_crashing_provider_is_treated_as_a_failure_not_propagated(
         self, request_obj
     ):
@@ -284,6 +293,7 @@ class TestLLMManagerCompletionFallback:
 
 
 class TestLLMManagerStreamingFallback:
+    @pytest.mark.asyncio
     async def test_stream_uses_the_primary_when_it_works(self, request_obj):
         primary = RecordingProvider("groq", chunks=["a", "b"])
         fallback = RecordingProvider("maritaca")
@@ -298,6 +308,7 @@ class TestLLMManagerStreamingFallback:
         assert chunks == ["a", "b"]
         assert fallback.stream_calls == 0
 
+    @pytest.mark.asyncio
     async def test_stream_falls_back_when_the_primary_fails(self, request_obj):
         primary = RecordingProvider("groq", error=LLMError("stream down"))
         fallback = RecordingProvider("maritaca", chunks=["oi", " mundo"])
@@ -312,6 +323,7 @@ class TestLLMManagerStreamingFallback:
         assert chunks == ["oi", " mundo"]
         assert primary.stream_calls == 1
 
+    @pytest.mark.asyncio
     async def test_stream_with_all_providers_down_raises(self, request_obj):
         primary = RecordingProvider("groq", error=LLMError("down"))
         fallback = RecordingProvider("maritaca", error=LLMError("also down"))
@@ -327,6 +339,7 @@ class TestLLMManagerStreamingFallback:
         assert "All LLM providers failed for streaming" in str(exc_info.value)
         assert "also down" in str(exc_info.value)
 
+    @pytest.mark.asyncio
     async def test_stream_with_fallback_disabled_does_not_contact_the_backup(
         self, request_obj
     ):
@@ -346,6 +359,7 @@ class TestLLMManagerStreamingFallback:
 
 
 class TestLLMManagerLifecycle:
+    @pytest.mark.asyncio
     async def test_close_closes_every_provider(self):
         providers = {
             LLMProvider.GROQ: RecordingProvider("groq"),
@@ -413,6 +427,7 @@ def groq_without_pool():
 
 
 class TestNonStreamRequest:
+    @pytest.mark.asyncio
     async def test_successful_response_is_parsed_and_not_retried(
         self, groq_without_pool, no_sleep
     ):
@@ -426,6 +441,7 @@ class TestNonStreamRequest:
         assert client.post.await_count == 1
         no_sleep.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_persistent_server_error_raises_after_exhausting_retries(
         self, groq_without_pool, no_sleep
     ):
@@ -439,6 +455,7 @@ class TestNonStreamRequest:
         assert "500" in str(exc_info.value)
         assert client.post.await_count == groq_without_pool.max_retries + 1
 
+    @pytest.mark.asyncio
     async def test_transient_server_error_is_retried_and_then_succeeds(
         self, groq_without_pool, no_sleep
     ):
@@ -456,6 +473,7 @@ class TestNonStreamRequest:
         assert result == {"ok": True}
         assert client.post.await_count == 2
 
+    @pytest.mark.asyncio
     async def test_rate_limit_raises_a_dedicated_error_with_retry_after(
         self, groq_without_pool, no_sleep
     ):
@@ -475,6 +493,7 @@ class TestNonStreamRequest:
             no_sleep.await_args_list[0].args[0] == 7
         ), "the server-provided Retry-After must drive the backoff"
 
+    @pytest.mark.asyncio
     async def test_rate_limit_followed_by_success_is_transparent(
         self, groq_without_pool, no_sleep
     ):
@@ -489,6 +508,7 @@ class TestNonStreamRequest:
 
         assert await groq_without_pool._non_stream_request("/x", {}) == {"ok": True}
 
+    @pytest.mark.asyncio
     async def test_timeout_is_retried_then_reported_as_llm_error(
         self, groq_without_pool, no_sleep
     ):
@@ -502,6 +522,7 @@ class TestNonStreamRequest:
         assert "timeout" in str(exc_info.value).lower()
         assert client.post.await_count == groq_without_pool.max_retries + 1
 
+    @pytest.mark.asyncio
     async def test_timeout_then_success_recovers(self, groq_without_pool, no_sleep):
         client = AsyncMock()
         client.post = AsyncMock(
@@ -514,6 +535,7 @@ class TestNonStreamRequest:
 
         assert await groq_without_pool._non_stream_request("/x", {}) == {"ok": True}
 
+    @pytest.mark.asyncio
     async def test_connection_error_is_wrapped_in_llm_error(
         self, groq_without_pool, no_sleep
     ):
@@ -527,6 +549,7 @@ class TestNonStreamRequest:
         assert "dns failure" in str(exc_info.value)
         assert exc_info.value.details["provider"] == "GroqProvider"
 
+    @pytest.mark.asyncio
     async def test_auth_header_carries_the_configured_key(self, groq_without_pool):
         headers = groq_without_pool._get_headers()
 
@@ -535,6 +558,7 @@ class TestNonStreamRequest:
 
 
 class TestConnectionPoolPath:
+    @pytest.mark.asyncio
     async def test_pool_is_used_when_available(self, no_sleep):
         provider = GroqProvider(api_key="gsk-unit-test")
         client = AsyncMock()
@@ -549,6 +573,7 @@ class TestConnectionPoolPath:
         pool.post.assert_awaited_once_with("groq", "/chat/completions", {"a": 1})
         client.post.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_pool_failure_degrades_to_the_direct_client(self, no_sleep):
         provider = GroqProvider(api_key="gsk-unit-test")
         client = AsyncMock()
@@ -610,6 +635,7 @@ class FakeStreamingClient:
 
 
 class TestStreamRequest:
+    @pytest.mark.asyncio
     async def test_sse_chunks_are_parsed_and_done_terminates_the_stream(
         self, groq_without_pool, no_sleep
     ):
@@ -636,6 +662,7 @@ class TestStreamRequest:
             " Brasil",
         ]
 
+    @pytest.mark.asyncio
     async def test_streaming_rate_limit_keeps_its_type(
         self, groq_without_pool, no_sleep
     ):
@@ -646,6 +673,7 @@ class TestStreamRequest:
         with pytest.raises(LLMRateLimitError):
             [c async for c in groq_without_pool._stream_request("/x", {})]
 
+    @pytest.mark.asyncio
     async def test_streaming_upstream_error_raises_after_retries(
         self, groq_without_pool, no_sleep
     ):
@@ -658,6 +686,7 @@ class TestStreamRequest:
         assert "502" in str(exc_info.value)
         assert client.calls == groq_without_pool.max_retries + 1
 
+    @pytest.mark.asyncio
     async def test_streaming_timeout_raises_a_dedicated_message(
         self, groq_without_pool, no_sleep
     ):
@@ -670,6 +699,7 @@ class TestStreamRequest:
 
         assert "Stream request timeout" in str(exc_info.value)
 
+    @pytest.mark.asyncio
     async def test_streaming_recovers_after_a_transient_failure(
         self, groq_without_pool, no_sleep
     ):
@@ -688,6 +718,7 @@ class TestStreamRequest:
 
 
 class TestProviderLifecycle:
+    @pytest.mark.asyncio
     async def test_close_releases_the_http_client(self):
         provider = GroqProvider(api_key="k")
         client = AsyncMock()
@@ -697,12 +728,14 @@ class TestProviderLifecycle:
 
         client.aclose.assert_awaited_once()
 
+    @pytest.mark.asyncio
     async def test_close_is_safe_when_no_client_was_created(self):
         provider = GroqProvider(api_key="k")
         provider.client = None
 
         await provider.close()  # must not raise
 
+    @pytest.mark.asyncio
     async def test_context_manager_builds_a_client_when_the_pool_is_disabled(self):
         provider = GroqProvider(api_key="k")
         provider._use_pool = False
@@ -767,6 +800,7 @@ class TestGroqProvider:
         assert response.metadata["response_id"] == "resp-1"
         assert response.response_time == 1.5
 
+    @pytest.mark.asyncio
     async def test_complete_goes_through_the_http_layer(self, request_obj):
         provider = GroqProvider(api_key="k")
         payload = {
@@ -781,6 +815,7 @@ class TestGroqProvider:
         assert response.content == "ok"
         assert provider._make_request.await_args.args[0] == "/chat/completions"
 
+    @pytest.mark.asyncio
     async def test_stream_yields_only_content_deltas(self, request_obj):
         provider = GroqProvider(api_key="k")
 
@@ -826,6 +861,7 @@ class TestTogetherProvider:
         assert data["messages"][0]["role"] == "system"
         assert data["model"] == provider.default_model
 
+    @pytest.mark.asyncio
     async def test_complete_posts_to_the_chat_endpoint(self, request_obj):
         provider = TogetherProvider(api_key="k")
         provider._make_request = AsyncMock(
@@ -841,6 +877,7 @@ class TestTogetherProvider:
         assert response.provider == "together"
         assert provider._make_request.await_args.args[0] == "/chat/completions"
 
+    @pytest.mark.asyncio
     async def test_stream_yields_content_deltas(self, request_obj):
         provider = TogetherProvider(api_key="k")
 
@@ -899,6 +936,7 @@ class TestHuggingFaceProvider:
 
         assert response.content == "resposta"
 
+    @pytest.mark.asyncio
     async def test_complete_targets_the_model_specific_endpoint(self):
         provider = HuggingFaceProvider(api_key="k")
         provider._make_request = AsyncMock(return_value=[{"generated_text": "ok"}])
@@ -917,6 +955,7 @@ class TestHuggingFaceProvider:
 
         assert headers["Authorization"] == "Bearer hf-key"
 
+    @pytest.mark.asyncio
     async def test_streaming_degrades_to_a_single_chunk(self, request_obj):
         provider = HuggingFaceProvider(api_key="k")
         provider.complete = AsyncMock(return_value=make_response("huggingface", "tudo"))
@@ -983,6 +1022,7 @@ class TestMaritacaProviderCompletion:
             client_cls.return_value.chat_completion = chat_completion
             return MaritacaProvider(api_key="k")
 
+    @pytest.mark.asyncio
     async def test_client_response_is_mapped_to_the_common_shape(self, request_obj):
         client_response = MagicMock(
             content="tres contratos suspeitos",
@@ -1001,6 +1041,7 @@ class TestMaritacaProviderCompletion:
         assert response.model == "sabia-4"
         assert response.usage == {"total_tokens": 120}
 
+    @pytest.mark.asyncio
     async def test_system_prompt_is_sent_first(self):
         provider = self._provider(
             AsyncMock(
@@ -1027,12 +1068,14 @@ class TestMaritacaProviderCompletion:
         assert messages[0]["role"] == "system"
         assert messages[1]["content"] == "oi"
 
+    @pytest.mark.asyncio
     async def test_client_failure_is_not_swallowed(self, request_obj):
         provider = self._provider(AsyncMock(side_effect=LLMError("maritaca 500")))
 
         with pytest.raises(LLMError, match="maritaca 500"):
             await provider.complete(request_obj)
 
+    @pytest.mark.asyncio
     async def test_rate_limit_from_the_client_keeps_its_type(self, request_obj):
         provider = self._provider(
             AsyncMock(side_effect=LLMRateLimitError("too many requests"))
@@ -1041,6 +1084,7 @@ class TestMaritacaProviderCompletion:
         with pytest.raises(LLMRateLimitError):
             await provider.complete(request_obj)
 
+    @pytest.mark.asyncio
     async def test_streaming_degrades_to_a_single_chunk(self, request_obj):
         provider = self._provider(AsyncMock())
         provider.complete = AsyncMock(return_value=make_response("maritaca", "texto"))

--- a/tests/unit/llm/test_providers.py
+++ b/tests/unit/llm/test_providers.py
@@ -225,9 +225,9 @@ class TestLLMManagerCompletionFallback:
             await manager.complete(request_obj)
 
         assert "All LLM providers failed" in str(exc_info.value)
-        assert "maritaca quota exhausted" in str(exc_info.value), (
-            "the last error must survive so the outage is diagnosable"
-        )
+        assert "maritaca quota exhausted" in str(
+            exc_info.value
+        ), "the last error must survive so the outage is diagnosable"
         assert exc_info.value.details == {"provider": "all"}
         assert fallback.complete_calls == 1
 
@@ -471,9 +471,9 @@ class TestNonStreamRequest:
             await groq_without_pool._non_stream_request("/chat/completions", {})
 
         assert exc_info.value.details["retry_after"] == 7
-        assert no_sleep.await_args_list[0].args[0] == 7, (
-            "the server-provided Retry-After must drive the backoff"
-        )
+        assert (
+            no_sleep.await_args_list[0].args[0] == 7
+        ), "the server-provided Retry-After must drive the backoff"
 
     async def test_rate_limit_followed_by_success_is_transparent(
         self, groq_without_pool, no_sleep

--- a/tests/unit/llm/test_providers.py
+++ b/tests/unit/llm/test_providers.py
@@ -1,0 +1,1079 @@
+"""
+Unit tests for src/llm/providers.py.
+
+The behaviour that matters here is the failure path: what happens when the
+primary provider is down, when every provider is down, and when no API key is
+configured. A silent degradation in this chain is invisible in production and
+shows up only as bad answers, so each test asserts which providers were
+actually contacted, not just the returned value.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from src.core.exceptions import LLMError, LLMRateLimitError
+from src.llm import providers as providers_mod
+from src.llm.providers import (
+    GroqProvider,
+    HuggingFaceProvider,
+    LLMManager,
+    LLMProvider,
+    LLMRequest,
+    LLMResponse,
+    MaritacaProvider,
+    TogetherProvider,
+    create_llm_manager,
+)
+
+
+def make_response(provider: str, content: str = "resposta") -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        provider=provider,
+        model=f"{provider}-model",
+        usage={"total_tokens": 42},
+        metadata={},
+        response_time=0.1,
+        timestamp=datetime.now(UTC),
+    )
+
+
+class RecordingProvider:
+    """A provider double that records every interaction and can really fail."""
+
+    def __init__(self, name: str, error: Exception | None = None, chunks=None):
+        self.name = name
+        self.error = error
+        self.chunks = chunks if chunks is not None else [f"{name}-chunk"]
+        self.complete_calls = 0
+        self.stream_calls = 0
+        self.enter_calls = 0
+        self.exit_calls = 0
+        self.close_calls = 0
+
+    async def __aenter__(self):
+        self.enter_calls += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.exit_calls += 1
+        return False
+
+    async def complete(self, request):
+        self.complete_calls += 1
+        if self.error:
+            raise self.error
+        return make_response(self.name)
+
+    async def stream_complete(self, request):
+        self.stream_calls += 1
+        if self.error:
+            raise self.error
+        for chunk in self.chunks:
+            yield chunk
+
+    async def close(self):
+        self.close_calls += 1
+
+
+def build_manager(primary, providers, fallbacks=None, enable_fallback=True):
+    """Create an LLMManager without instantiating the real HTTP providers."""
+    with (
+        patch.object(providers_mod, "GroqProvider"),
+        patch.object(providers_mod, "TogetherProvider"),
+        patch.object(providers_mod, "HuggingFaceProvider"),
+        patch.object(providers_mod, "MaritacaProvider"),
+    ):
+        manager = LLMManager(
+            primary_provider=primary,
+            fallback_providers=fallbacks,
+            enable_fallback=enable_fallback,
+        )
+    manager.providers = providers
+    return manager
+
+
+@pytest.fixture
+def request_obj():
+    return LLMRequest(messages=[{"role": "user", "content": "quem gastou mais?"}])
+
+
+@pytest.fixture
+def no_sleep():
+    """Retry backoff must not actually sleep during unit tests."""
+    with patch.object(providers_mod.asyncio, "sleep", new=AsyncMock()) as slept:
+        yield slept
+
+
+# ---------------------------------------------------------------------------
+# LLMManager — the fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestLLMManagerCompletionFallback:
+    async def test_primary_success_never_touches_the_fallbacks(self, request_obj):
+        primary = RecordingProvider("groq")
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        response = await manager.complete(request_obj)
+
+        assert response.provider == "groq"
+        assert primary.complete_calls == 1
+        assert fallback.complete_calls == 0
+
+    async def test_primary_failure_is_served_by_the_next_provider(self, request_obj):
+        primary = RecordingProvider("groq", error=LLMError("groq is down"))
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        response = await manager.complete(request_obj)
+
+        assert response.provider == "maritaca"
+        assert primary.complete_calls == 1, "the primary must have been tried first"
+        assert fallback.complete_calls == 1
+
+    async def test_maritaca_primary_still_falls_back_with_the_default_chain(
+        self, request_obj
+    ):
+        # This is the documented production configuration: Maritaca is primary
+        # and also appears in the default fallback list. The chain must not
+        # collapse into "primary only" because of that overlap.
+        maritaca = RecordingProvider("maritaca", error=LLMError("503 from maritaca"))
+        together = RecordingProvider("together")
+        huggingface = RecordingProvider("huggingface")
+        manager = build_manager(
+            LLMProvider.MARITACA,
+            {
+                LLMProvider.MARITACA: maritaca,
+                LLMProvider.TOGETHER: together,
+                LLMProvider.HUGGINGFACE: huggingface,
+            },
+            fallbacks=None,  # defaults to [TOGETHER, HUGGINGFACE, MARITACA]
+        )
+
+        response = await manager.complete(request_obj)
+
+        assert response.provider == "together"
+        assert maritaca.complete_calls == 1
+        assert together.complete_calls == 1
+
+    async def test_a_provider_is_never_retried_twice_in_one_chain(self, request_obj):
+        maritaca = RecordingProvider("maritaca", error=LLMError("down"))
+        together = RecordingProvider("together", error=LLMError("down"))
+        huggingface = RecordingProvider("huggingface", error=LLMError("down"))
+        manager = build_manager(
+            LLMProvider.MARITACA,
+            {
+                LLMProvider.MARITACA: maritaca,
+                LLMProvider.TOGETHER: together,
+                LLMProvider.HUGGINGFACE: huggingface,
+            },
+            fallbacks=None,
+        )
+
+        with pytest.raises(LLMError):
+            await manager.complete(request_obj)
+
+        assert maritaca.complete_calls == 1, "duplicated provider must not be re-tried"
+
+    async def test_fallback_order_is_respected(self, request_obj):
+        first = RecordingProvider("together", error=LLMError("down"))
+        second = RecordingProvider("huggingface")
+        primary = RecordingProvider("groq", error=LLMError("down"))
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {
+                LLMProvider.GROQ: primary,
+                LLMProvider.TOGETHER: first,
+                LLMProvider.HUGGINGFACE: second,
+            },
+            fallbacks=[LLMProvider.TOGETHER, LLMProvider.HUGGINGFACE],
+        )
+
+        response = await manager.complete(request_obj)
+
+        assert response.provider == "huggingface"
+        assert first.complete_calls == 1
+
+    async def test_all_providers_down_raises_instead_of_returning_empty(
+        self, request_obj
+    ):
+        primary = RecordingProvider("groq", error=LLMError("groq down"))
+        fallback = RecordingProvider(
+            "maritaca", error=LLMRateLimitError("maritaca quota exhausted")
+        )
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        with pytest.raises(LLMError) as exc_info:
+            await manager.complete(request_obj)
+
+        assert "All LLM providers failed" in str(exc_info.value)
+        assert "maritaca quota exhausted" in str(exc_info.value), (
+            "the last error must survive so the outage is diagnosable"
+        )
+        assert exc_info.value.details == {"provider": "all"}
+        assert fallback.complete_calls == 1
+
+    async def test_fallback_disabled_means_the_backup_is_never_contacted(
+        self, request_obj
+    ):
+        primary = RecordingProvider("groq", error=LLMError("groq down"))
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+            enable_fallback=False,
+        )
+
+        with pytest.raises(LLMError):
+            await manager.complete(request_obj)
+
+        assert fallback.complete_calls == 0
+        assert fallback.enter_calls == 0
+
+    async def test_context_manager_is_exited_even_when_the_provider_fails(
+        self, request_obj
+    ):
+        primary = RecordingProvider("groq", error=LLMError("boom"))
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        await manager.complete(request_obj)
+
+        assert primary.enter_calls == 1
+        assert primary.exit_calls == 1, "a failed provider must still be closed"
+
+    async def test_a_crashing_provider_is_treated_as_a_failure_not_propagated(
+        self, request_obj
+    ):
+        # A bug inside a provider (not an LLMError) must not escape as-is;
+        # the manager is expected to move on to the next provider.
+        primary = RecordingProvider("groq", error=RuntimeError("bad json"))
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        response = await manager.complete(request_obj)
+
+        assert response.provider == "maritaca"
+
+
+class TestLLMManagerStreamingFallback:
+    async def test_stream_uses_the_primary_when_it_works(self, request_obj):
+        primary = RecordingProvider("groq", chunks=["a", "b"])
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        chunks = [c async for c in manager.stream_complete(request_obj)]
+
+        assert chunks == ["a", "b"]
+        assert fallback.stream_calls == 0
+
+    async def test_stream_falls_back_when_the_primary_fails(self, request_obj):
+        primary = RecordingProvider("groq", error=LLMError("stream down"))
+        fallback = RecordingProvider("maritaca", chunks=["oi", " mundo"])
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        chunks = [c async for c in manager.stream_complete(request_obj)]
+
+        assert chunks == ["oi", " mundo"]
+        assert primary.stream_calls == 1
+
+    async def test_stream_with_all_providers_down_raises(self, request_obj):
+        primary = RecordingProvider("groq", error=LLMError("down"))
+        fallback = RecordingProvider("maritaca", error=LLMError("also down"))
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+        )
+
+        with pytest.raises(LLMError) as exc_info:
+            [c async for c in manager.stream_complete(request_obj)]
+
+        assert "All LLM providers failed for streaming" in str(exc_info.value)
+        assert "also down" in str(exc_info.value)
+
+    async def test_stream_with_fallback_disabled_does_not_contact_the_backup(
+        self, request_obj
+    ):
+        primary = RecordingProvider("groq", error=LLMError("down"))
+        fallback = RecordingProvider("maritaca")
+        manager = build_manager(
+            LLMProvider.GROQ,
+            {LLMProvider.GROQ: primary, LLMProvider.MARITACA: fallback},
+            fallbacks=[LLMProvider.MARITACA],
+            enable_fallback=False,
+        )
+
+        with pytest.raises(LLMError):
+            [c async for c in manager.stream_complete(request_obj)]
+
+        assert fallback.stream_calls == 0
+
+
+class TestLLMManagerLifecycle:
+    async def test_close_closes_every_provider(self):
+        providers = {
+            LLMProvider.GROQ: RecordingProvider("groq"),
+            LLMProvider.MARITACA: RecordingProvider("maritaca"),
+        }
+        manager = build_manager(LLMProvider.GROQ, providers)
+
+        await manager.close()
+
+        assert all(p.close_calls == 1 for p in providers.values())
+
+
+class TestCreateLLMManager:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("maritaca", LLMProvider.MARITACA),
+            ("MARITACA", LLMProvider.MARITACA),
+            ("groq", LLMProvider.GROQ),
+            ("Together", LLMProvider.TOGETHER),
+        ],
+    )
+    def test_provider_name_is_resolved_case_insensitively(self, name, expected):
+        with (
+            patch.object(providers_mod, "GroqProvider"),
+            patch.object(providers_mod, "TogetherProvider"),
+            patch.object(providers_mod, "HuggingFaceProvider"),
+            patch.object(providers_mod, "MaritacaProvider"),
+        ):
+            manager = create_llm_manager(primary_provider=name)
+
+        assert manager.primary_provider is expected
+
+    def test_unknown_provider_name_fails_loudly(self):
+        with pytest.raises(ValueError):
+            create_llm_manager(primary_provider="does-not-exist")
+
+    def test_anthropic_is_not_a_provider_in_this_module(self):
+        # The architecture doc describes Anthropic as the Maritaca fallback,
+        # but this module only knows groq/together/huggingface/maritaca.
+        # If Anthropic is ever added here, this test should be updated.
+        with pytest.raises(ValueError):
+            create_llm_manager(primary_provider="anthropic")
+
+
+# ---------------------------------------------------------------------------
+# BaseLLMProvider — HTTP error handling and retries
+# ---------------------------------------------------------------------------
+
+
+def http_response(status_code: int, payload=None, headers=None) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload if payload is not None else {"detail": "err"},
+        headers=headers or {},
+        request=httpx.Request("POST", "https://example.test/chat/completions"),
+    )
+
+
+@pytest.fixture
+def groq_without_pool():
+    provider = GroqProvider(api_key="gsk-unit-test")
+    provider._use_pool = False
+    return provider
+
+
+class TestNonStreamRequest:
+    async def test_successful_response_is_parsed_and_not_retried(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=http_response(200, {"ok": True}))
+        groq_without_pool.client = client
+
+        result = await groq_without_pool._non_stream_request("/chat/completions", {})
+
+        assert result == {"ok": True}
+        assert client.post.await_count == 1
+        no_sleep.assert_not_awaited()
+
+    async def test_persistent_server_error_raises_after_exhausting_retries(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=http_response(500, {"error": "boom"}))
+        groq_without_pool.client = client
+
+        with pytest.raises(LLMError) as exc_info:
+            await groq_without_pool._non_stream_request("/chat/completions", {})
+
+        assert "500" in str(exc_info.value)
+        assert client.post.await_count == groq_without_pool.max_retries + 1
+
+    async def test_transient_server_error_is_retried_and_then_succeeds(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(
+            side_effect=[
+                http_response(500, {"error": "boom"}),
+                http_response(200, {"ok": True}),
+            ]
+        )
+        groq_without_pool.client = client
+
+        result = await groq_without_pool._non_stream_request("/chat/completions", {})
+
+        assert result == {"ok": True}
+        assert client.post.await_count == 2
+
+    async def test_rate_limit_raises_a_dedicated_error_with_retry_after(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(
+            return_value=http_response(
+                429, {"error": "slow down"}, {"Retry-After": "7"}
+            )
+        )
+        groq_without_pool.client = client
+
+        with pytest.raises(LLMRateLimitError) as exc_info:
+            await groq_without_pool._non_stream_request("/chat/completions", {})
+
+        assert exc_info.value.details["retry_after"] == 7
+        assert no_sleep.await_args_list[0].args[0] == 7, (
+            "the server-provided Retry-After must drive the backoff"
+        )
+
+    async def test_rate_limit_followed_by_success_is_transparent(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(
+            side_effect=[
+                http_response(429, {"error": "slow down"}, {"Retry-After": "1"}),
+                http_response(200, {"ok": True}),
+            ]
+        )
+        groq_without_pool.client = client
+
+        assert await groq_without_pool._non_stream_request("/x", {}) == {"ok": True}
+
+    async def test_timeout_is_retried_then_reported_as_llm_error(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+        groq_without_pool.client = client
+
+        with pytest.raises(LLMError) as exc_info:
+            await groq_without_pool._non_stream_request("/chat/completions", {})
+
+        assert "timeout" in str(exc_info.value).lower()
+        assert client.post.await_count == groq_without_pool.max_retries + 1
+
+    async def test_timeout_then_success_recovers(self, groq_without_pool, no_sleep):
+        client = AsyncMock()
+        client.post = AsyncMock(
+            side_effect=[
+                httpx.TimeoutException("timed out"),
+                http_response(200, {"ok": True}),
+            ]
+        )
+        groq_without_pool.client = client
+
+        assert await groq_without_pool._non_stream_request("/x", {}) == {"ok": True}
+
+    async def test_connection_error_is_wrapped_in_llm_error(
+        self, groq_without_pool, no_sleep
+    ):
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=httpx.ConnectError("dns failure"))
+        groq_without_pool.client = client
+
+        with pytest.raises(LLMError) as exc_info:
+            await groq_without_pool._non_stream_request("/x", {})
+
+        assert "dns failure" in str(exc_info.value)
+        assert exc_info.value.details["provider"] == "GroqProvider"
+
+    async def test_auth_header_carries_the_configured_key(self, groq_without_pool):
+        headers = groq_without_pool._get_headers()
+
+        assert headers["Authorization"] == "Bearer gsk-unit-test"
+        assert headers["Content-Type"] == "application/json"
+
+
+class TestConnectionPoolPath:
+    async def test_pool_is_used_when_available(self, no_sleep):
+        provider = GroqProvider(api_key="gsk-unit-test")
+        client = AsyncMock()
+        provider.client = client
+        pool = MagicMock()
+        pool.post = AsyncMock(return_value={"from": "pool"})
+
+        with patch.object(providers_mod, "get_llm_pool", AsyncMock(return_value=pool)):
+            result = await provider._non_stream_request("/chat/completions", {"a": 1})
+
+        assert result == {"from": "pool"}
+        pool.post.assert_awaited_once_with("groq", "/chat/completions", {"a": 1})
+        client.post.assert_not_awaited()
+
+    async def test_pool_failure_degrades_to_the_direct_client(self, no_sleep):
+        provider = GroqProvider(api_key="gsk-unit-test")
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=http_response(200, {"from": "direct"}))
+        provider.client = client
+
+        with patch.object(
+            providers_mod,
+            "get_llm_pool",
+            AsyncMock(side_effect=RuntimeError("pool exhausted")),
+        ):
+            result = await provider._non_stream_request("/chat/completions", {})
+
+        assert result == {"from": "direct"}
+        assert client.post.await_count == 1
+
+
+class FakeStreamResponse:
+    """Minimal stand-in for an httpx streaming response."""
+
+    def __init__(self, status_code: int, lines=(), payload=None, headers=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = "upstream error"
+        self._lines = list(lines)
+        self._payload = payload
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json body")
+        return self._payload
+
+
+class FakeStreamingClient:
+    """Client whose .stream() replays scripted responses or raises."""
+
+    def __init__(self, script):
+        self.script = list(script)
+        self.calls = 0
+
+    def stream(self, method, url, **kwargs):
+        self.calls += 1
+        item = self.script[min(self.calls - 1, len(self.script) - 1)]
+        if isinstance(item, Exception):
+            raise item
+
+        class _Ctx:
+            async def __aenter__(_self):
+                return item
+
+            async def __aexit__(_self, *exc):
+                return False
+
+        return _Ctx()
+
+
+class TestStreamRequest:
+    async def test_sse_chunks_are_parsed_and_done_terminates_the_stream(
+        self, groq_without_pool, no_sleep
+    ):
+        groq_without_pool.client = FakeStreamingClient(
+            [
+                FakeStreamResponse(
+                    200,
+                    lines=[
+                        'data: {"choices": [{"delta": {"content": "Oi"}}]}',
+                        "",
+                        "data: {not valid json",
+                        'data: {"choices": [{"delta": {"content": " Brasil"}}]}',
+                        "data: [DONE]",
+                        'data: {"choices": [{"delta": {"content": "nunca"}}]}',
+                    ],
+                )
+            ]
+        )
+
+        chunks = [c async for c in groq_without_pool._stream_request("/x", {})]
+
+        assert [c["choices"][0]["delta"]["content"] for c in chunks] == [
+            "Oi",
+            " Brasil",
+        ]
+
+    async def test_streaming_rate_limit_keeps_its_type(
+        self, groq_without_pool, no_sleep
+    ):
+        groq_without_pool.client = FakeStreamingClient(
+            [FakeStreamResponse(429, headers={"Retry-After": "3"})]
+        )
+
+        with pytest.raises(LLMRateLimitError):
+            [c async for c in groq_without_pool._stream_request("/x", {})]
+
+    async def test_streaming_upstream_error_raises_after_retries(
+        self, groq_without_pool, no_sleep
+    ):
+        client = FakeStreamingClient([FakeStreamResponse(502)])
+        groq_without_pool.client = client
+
+        with pytest.raises(LLMError) as exc_info:
+            [c async for c in groq_without_pool._stream_request("/x", {})]
+
+        assert "502" in str(exc_info.value)
+        assert client.calls == groq_without_pool.max_retries + 1
+
+    async def test_streaming_timeout_raises_a_dedicated_message(
+        self, groq_without_pool, no_sleep
+    ):
+        groq_without_pool.client = FakeStreamingClient(
+            [httpx.TimeoutException("timed out")]
+        )
+
+        with pytest.raises(LLMError) as exc_info:
+            [c async for c in groq_without_pool._stream_request("/x", {})]
+
+        assert "Stream request timeout" in str(exc_info.value)
+
+    async def test_streaming_recovers_after_a_transient_failure(
+        self, groq_without_pool, no_sleep
+    ):
+        groq_without_pool.client = FakeStreamingClient(
+            [
+                httpx.TimeoutException("timed out"),
+                FakeStreamResponse(
+                    200, lines=['data: {"choices": [{"delta": {"content": "ok"}}]}']
+                ),
+            ]
+        )
+
+        chunks = [c async for c in groq_without_pool._stream_request("/x", {})]
+
+        assert len(chunks) == 1
+
+
+class TestProviderLifecycle:
+    async def test_close_releases_the_http_client(self):
+        provider = GroqProvider(api_key="k")
+        client = AsyncMock()
+        provider.client = client
+
+        await provider.close()
+
+        client.aclose.assert_awaited_once()
+
+    async def test_close_is_safe_when_no_client_was_created(self):
+        provider = GroqProvider(api_key="k")
+        provider.client = None
+
+        await provider.close()  # must not raise
+
+    async def test_context_manager_builds_a_client_when_the_pool_is_disabled(self):
+        provider = GroqProvider(api_key="k")
+        provider._use_pool = False
+
+        async with provider as entered:
+            assert entered is provider
+            assert provider.client is not None
+
+        assert provider.client.is_closed
+
+
+# ---------------------------------------------------------------------------
+# Provider payload shaping
+# ---------------------------------------------------------------------------
+
+
+class TestGroqProvider:
+    def test_system_prompt_is_prepended_to_the_conversation(self):
+        provider = GroqProvider(api_key="k")
+        request = LLMRequest(
+            messages=[{"role": "user", "content": "oi"}],
+            system_prompt="voce e um auditor",
+            temperature=0.1,
+            max_tokens=128,
+        )
+
+        data = provider._prepare_request_data(request)
+
+        assert data["messages"][0] == {
+            "role": "system",
+            "content": "voce e um auditor",
+        }
+        assert data["messages"][1] == {"role": "user", "content": "oi"}
+        assert data["temperature"] == 0.1
+        assert data["max_tokens"] == 128
+        assert data["model"] == provider.default_model
+
+    def test_explicit_model_overrides_the_default(self):
+        provider = GroqProvider(api_key="k")
+        request = LLMRequest(messages=[], model="llama-3.1-70b")
+
+        assert provider._prepare_request_data(request)["model"] == "llama-3.1-70b"
+
+    def test_response_is_mapped_to_the_common_shape(self):
+        provider = GroqProvider(api_key="k")
+        payload = {
+            "id": "resp-1",
+            "model": "mixtral",
+            "choices": [
+                {"message": {"content": "achei 3 anomalias"}, "finish_reason": "stop"}
+            ],
+            "usage": {"total_tokens": 99},
+        }
+
+        response = provider._parse_response(payload, response_time=1.5)
+
+        assert response.content == "achei 3 anomalias"
+        assert response.provider == "groq"
+        assert response.model == "mixtral"
+        assert response.usage == {"total_tokens": 99}
+        assert response.metadata["finish_reason"] == "stop"
+        assert response.metadata["response_id"] == "resp-1"
+        assert response.response_time == 1.5
+
+    async def test_complete_goes_through_the_http_layer(self, request_obj):
+        provider = GroqProvider(api_key="k")
+        payload = {
+            "model": "mixtral",
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {},
+        }
+        provider._make_request = AsyncMock(return_value=payload)
+
+        response = await provider.complete(request_obj)
+
+        assert response.content == "ok"
+        assert provider._make_request.await_args.args[0] == "/chat/completions"
+
+    async def test_stream_yields_only_content_deltas(self, request_obj):
+        provider = GroqProvider(api_key="k")
+
+        async def fake_stream(endpoint, data, stream=False):
+            assert data["stream"] is True
+            for chunk in [
+                {"choices": [{"delta": {"role": "assistant"}}]},
+                {"choices": [{"delta": {"content": "Oi"}}]},
+                {"choices": []},
+                {"choices": [{"delta": {"content": " Brasil"}}]},
+            ]:
+                yield chunk
+
+        provider._make_request = fake_stream
+
+        chunks = [c async for c in provider.stream_complete(request_obj)]
+
+        assert chunks == ["Oi", " Brasil"]
+
+
+class TestTogetherProvider:
+    def test_response_is_tagged_with_the_right_provider(self):
+        provider = TogetherProvider(api_key="k")
+        payload = {
+            "model": "llama-2",
+            "choices": [{"message": {"content": "x"}, "finish_reason": "length"}],
+            "usage": {"total_tokens": 5},
+        }
+
+        response = provider._parse_response(payload, response_time=0.2)
+
+        assert response.provider == "together"
+        assert response.metadata["finish_reason"] == "length"
+
+    def test_system_prompt_is_prepended(self):
+        provider = TogetherProvider(api_key="k")
+        request = LLMRequest(
+            messages=[{"role": "user", "content": "oi"}], system_prompt="seja formal"
+        )
+
+        data = provider._prepare_request_data(request)
+
+        assert data["messages"][0]["role"] == "system"
+        assert data["model"] == provider.default_model
+
+    async def test_complete_posts_to_the_chat_endpoint(self, request_obj):
+        provider = TogetherProvider(api_key="k")
+        provider._make_request = AsyncMock(
+            return_value={
+                "model": "llama-2",
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {},
+            }
+        )
+
+        response = await provider.complete(request_obj)
+
+        assert response.provider == "together"
+        assert provider._make_request.await_args.args[0] == "/chat/completions"
+
+    async def test_stream_yields_content_deltas(self, request_obj):
+        provider = TogetherProvider(api_key="k")
+
+        async def fake_stream(endpoint, data, stream=False):
+            yield {"choices": [{"delta": {"content": "a"}}]}
+            yield {"choices": [{"delta": {}}]}
+            yield {"choices": [{"delta": {"content": "b"}}]}
+
+        provider._make_request = fake_stream
+
+        assert [c async for c in provider.stream_complete(request_obj)] == ["a", "b"]
+
+    def test_together_does_not_use_the_shared_pool(self):
+        # Only Groq declares a pool name; the others must not silently try to
+        # route through a pool entry that does not exist.
+        assert not hasattr(TogetherProvider(api_key="k"), "_provider_name")
+
+
+class TestHuggingFaceProvider:
+    def test_conversation_is_flattened_into_a_single_prompt(self):
+        provider = HuggingFaceProvider(api_key="k")
+        request = LLMRequest(
+            messages=[
+                {"role": "user", "content": "oi"},
+                {"role": "assistant", "content": "ola"},
+            ],
+            system_prompt="seja breve",
+            max_tokens=64,
+        )
+
+        data = provider._prepare_request_data(request)
+
+        assert data["inputs"] == (
+            "System: seja breve\n\nUser: oi\nAssistant: ola\nAssistant: "
+        )
+        assert data["parameters"]["max_new_tokens"] == 64
+        assert data["parameters"]["return_full_text"] is False
+
+    def test_list_shaped_response_is_understood(self):
+        provider = HuggingFaceProvider(api_key="k")
+
+        response = provider._parse_response(
+            [{"generated_text": "resposta"}], response_time=0.3, model="mistral"
+        )
+
+        assert response.content == "resposta"
+        assert response.provider == "huggingface"
+        assert response.model == "mistral"
+
+    def test_dict_shaped_response_is_understood(self):
+        provider = HuggingFaceProvider(api_key="k")
+
+        response = provider._parse_response(
+            {"generated_text": "resposta"}, response_time=0.3, model="mistral"
+        )
+
+        assert response.content == "resposta"
+
+    async def test_complete_targets_the_model_specific_endpoint(self):
+        provider = HuggingFaceProvider(api_key="k")
+        provider._make_request = AsyncMock(return_value=[{"generated_text": "ok"}])
+        request = LLMRequest(messages=[], model="meta-llama/Llama-3-8B")
+
+        response = await provider.complete(request)
+
+        assert provider._make_request.await_args.args[0] == (
+            "/models/meta-llama/Llama-3-8B"
+        )
+        assert response.model == "meta-llama/Llama-3-8B"
+        assert response.content == "ok"
+
+    def test_headers_carry_the_bearer_token(self):
+        headers = HuggingFaceProvider(api_key="hf-key")._get_headers()
+
+        assert headers["Authorization"] == "Bearer hf-key"
+
+    async def test_streaming_degrades_to_a_single_chunk(self, request_obj):
+        provider = HuggingFaceProvider(api_key="k")
+        provider.complete = AsyncMock(return_value=make_response("huggingface", "tudo"))
+
+        chunks = [c async for c in provider.stream_complete(request_obj)]
+
+        assert chunks == ["tudo"]
+
+
+# ---------------------------------------------------------------------------
+# MaritacaProvider — key handling and error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestMaritacaProviderKeys:
+    def test_explicit_key_wins_over_settings(self):
+        with patch.object(providers_mod, "MaritacaClient") as client_cls:
+            provider = MaritacaProvider(api_key="explicit-key")
+
+        assert provider.api_key == "explicit-key"
+        assert client_cls.call_args.kwargs["api_key"] == "explicit-key"
+
+    def test_configured_key_is_read_from_settings(self):
+        secret = MagicMock()
+        secret.get_secret_value.return_value = "settings-key"
+
+        with (
+            patch.object(providers_mod, "MaritacaClient"),
+            patch.object(providers_mod.settings, "maritaca_api_key", secret),
+        ):
+            provider = MaritacaProvider()
+
+        assert provider.api_key == "settings-key"
+
+    def test_missing_key_falls_back_to_a_dummy_key_and_warns(self):
+        # Documented behaviour: the provider does NOT refuse to start without a
+        # key, it builds a client with a placeholder that will 401 at call
+        # time. The warning is the only signal, so it must be emitted.
+        with (
+            patch.object(providers_mod, "MaritacaClient"),
+            patch.object(providers_mod.settings, "maritaca_api_key", None),
+            patch.object(providers_mod, "get_logger") as get_logger,
+        ):
+            logger = MagicMock()
+            get_logger.return_value = logger
+            provider = MaritacaProvider()
+
+        assert provider.api_key == "sk-test-dummy-key"
+        logger.warning.assert_called_once()
+        assert "MARITACA_API_KEY" in logger.warning.call_args.args[0]
+
+    def test_client_is_configured_for_fast_failure(self):
+        with patch.object(providers_mod, "MaritacaClient") as client_cls:
+            MaritacaProvider(api_key="k")
+
+        kwargs = client_cls.call_args.kwargs
+        assert kwargs["timeout"] == 30
+        assert kwargs["max_retries"] == 2
+
+
+class TestMaritacaProviderCompletion:
+    def _provider(self, chat_completion):
+        with patch.object(providers_mod, "MaritacaClient") as client_cls:
+            client_cls.return_value.chat_completion = chat_completion
+            return MaritacaProvider(api_key="k")
+
+    async def test_client_response_is_mapped_to_the_common_shape(self, request_obj):
+        client_response = MagicMock(
+            content="tres contratos suspeitos",
+            model="sabia-4",
+            usage={"total_tokens": 120},
+            metadata={"finish_reason": "stop"},
+            response_time=0.9,
+            timestamp=datetime.now(UTC),
+        )
+        provider = self._provider(AsyncMock(return_value=client_response))
+
+        response = await provider.complete(request_obj)
+
+        assert response.content == "tres contratos suspeitos"
+        assert response.provider == "maritaca"
+        assert response.model == "sabia-4"
+        assert response.usage == {"total_tokens": 120}
+
+    async def test_system_prompt_is_sent_first(self):
+        provider = self._provider(
+            AsyncMock(
+                return_value=MagicMock(
+                    content="x",
+                    model="sabia-4",
+                    usage={},
+                    metadata={},
+                    response_time=0.1,
+                    timestamp=datetime.now(UTC),
+                )
+            )
+        )
+        request = LLMRequest(
+            messages=[{"role": "user", "content": "oi"}],
+            system_prompt="voce e o Zumbi",
+        )
+
+        await provider.complete(request)
+
+        messages = provider.maritaca_client.chat_completion.await_args.kwargs[
+            "messages"
+        ]
+        assert messages[0]["role"] == "system"
+        assert messages[1]["content"] == "oi"
+
+    async def test_client_failure_is_not_swallowed(self, request_obj):
+        provider = self._provider(AsyncMock(side_effect=LLMError("maritaca 500")))
+
+        with pytest.raises(LLMError, match="maritaca 500"):
+            await provider.complete(request_obj)
+
+    async def test_rate_limit_from_the_client_keeps_its_type(self, request_obj):
+        provider = self._provider(
+            AsyncMock(side_effect=LLMRateLimitError("too many requests"))
+        )
+
+        with pytest.raises(LLMRateLimitError):
+            await provider.complete(request_obj)
+
+    async def test_streaming_degrades_to_a_single_chunk(self, request_obj):
+        provider = self._provider(AsyncMock())
+        provider.complete = AsyncMock(return_value=make_response("maritaca", "texto"))
+
+        chunks = [c async for c in provider.stream_complete(request_obj)]
+
+        assert chunks == ["texto"]
+
+
+# ---------------------------------------------------------------------------
+# LLMRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestLLMRequestValidation:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"temperature": 2.5},
+            {"temperature": -0.1},
+            {"max_tokens": 0},
+            {"max_tokens": 40000},
+            {"top_p": 1.5},
+        ],
+    )
+    def test_out_of_range_parameters_are_rejected(self, kwargs):
+        with pytest.raises(ValidationError):
+            LLMRequest(messages=[{"role": "user", "content": "oi"}], **kwargs)
+
+    def test_defaults_are_conservative(self):
+        request = LLMRequest(messages=[{"role": "user", "content": "oi"}])
+
+        assert request.temperature == 0.7
+        assert request.max_tokens == 2048
+        assert request.stream is False
+        assert request.model is None

--- a/tests/unit/middleware/test_security.py
+++ b/tests/unit/middleware/test_security.py
@@ -1,0 +1,692 @@
+"""
+Unit tests for src/api/middleware/security.py.
+
+These tests focus on the paths where the middleware is supposed to *deny*
+a request: blocked IPs, exhausted rate limits, malicious payloads and
+invalid CSRF tokens. The happy path is covered only as a control, so that a
+"deny everything" regression would also be caught.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from src.api.middleware.security import (
+    CSRFProtection,
+    IPBlockList,
+    RateLimiter,
+    RequestValidator,
+    SecurityConfig,
+    SecurityMiddleware,
+)
+
+PUBLIC_IP = "203.0.113.7"  # TEST-NET-3, never whitelisted
+
+
+def build_request(
+    path: str = "/api/v1/investigations",
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    query: str = "",
+    client_host: str | None = PUBLIC_IP,
+    body: bytes = b"",
+) -> Request:
+    """Build a real Starlette Request from an ASGI scope."""
+    raw_headers = [
+        (k.lower().encode("latin-1"), v.encode("latin-1"))
+        for k, v in (headers or {}).items()
+    ]
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "root_path": "",
+        "query_string": query.encode("utf-8"),
+        "headers": raw_headers,
+        "client": (client_host, 54321) if client_host else None,
+        "server": ("testserver", 80),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive=receive)
+
+
+@pytest.fixture
+def middleware():
+    """SecurityMiddleware with the audit sink replaced by a spy."""
+    mw = SecurityMiddleware(app=AsyncMock())
+    return mw
+
+
+@pytest.fixture
+def audit_spy():
+    """Replace the module-level audit logger so nothing is written to disk."""
+    with patch("src.api.middleware.security.audit_logger") as spy:
+        spy.log_event = AsyncMock()
+        yield spy.log_event
+
+
+async def call_next_ok(request):
+    return Response(content="ok", status_code=200)
+
+
+# ---------------------------------------------------------------------------
+# IPBlockList
+# ---------------------------------------------------------------------------
+
+
+class TestIPBlockList:
+    def test_ip_is_blocked_after_reaching_the_failure_threshold(self):
+        blocklist = IPBlockList()
+
+        for _ in range(SecurityConfig.MAX_FAILED_ATTEMPTS - 1):
+            blocklist.record_failed_attempt(PUBLIC_IP)
+        assert blocklist.is_blocked(PUBLIC_IP) is False, (
+            "IP must stay allowed below the threshold"
+        )
+
+        blocklist.record_failed_attempt(PUBLIC_IP)
+        assert blocklist.is_blocked(PUBLIC_IP) is True
+
+    def test_unknown_ip_is_not_blocked(self):
+        assert IPBlockList().is_blocked("198.51.100.4") is False
+
+    @pytest.mark.parametrize("ip", ["127.0.0.1", "192.168.1.50", "10.1.2.3"])
+    def test_whitelisted_ips_are_never_blocked(self, ip):
+        blocklist = IPBlockList()
+
+        for _ in range(SecurityConfig.MAX_FAILED_ATTEMPTS * 3):
+            blocklist.record_failed_attempt(ip)
+
+        assert blocklist.is_whitelisted(ip) is True
+        assert blocklist.is_blocked(ip) is False
+        assert blocklist.failed_attempts[ip] == [], (
+            "whitelisted IPs must not accumulate failed attempts"
+        )
+
+    def test_block_expires_after_the_configured_duration(self):
+        blocklist = IPBlockList()
+        for _ in range(SecurityConfig.MAX_FAILED_ATTEMPTS):
+            blocklist.record_failed_attempt(PUBLIC_IP)
+        assert blocklist.is_blocked(PUBLIC_IP) is True
+
+        blocklist.blocked_ips[PUBLIC_IP] = datetime.now(UTC) - timedelta(
+            minutes=SecurityConfig.BLOCK_DURATION_MINUTES + 1
+        )
+
+        assert blocklist.is_blocked(PUBLIC_IP) is False
+        assert PUBLIC_IP not in blocklist.blocked_ips, "expired block must be dropped"
+
+    def test_malformed_ip_is_not_treated_as_whitelisted(self):
+        blocklist = IPBlockList()
+        assert blocklist.is_whitelisted("not-an-ip") is False
+        assert blocklist.is_whitelisted("") is False
+
+    def test_failed_attempt_count_only_covers_the_requested_window(self):
+        blocklist = IPBlockList()
+        now = datetime.now(UTC)
+        blocklist.failed_attempts[PUBLIC_IP] = [
+            now - timedelta(minutes=90),
+            now - timedelta(minutes=45),
+            now - timedelta(minutes=1),
+        ]
+
+        assert blocklist.get_failed_attempts_count(PUBLIC_IP, window_minutes=60) == 2
+        assert blocklist.get_failed_attempts_count(PUBLIC_IP, window_minutes=5) == 1
+        assert blocklist.get_failed_attempts_count("198.51.100.9") == 0
+
+    def test_old_failures_are_pruned_so_a_slow_attacker_is_not_blocked(self):
+        blocklist = IPBlockList()
+        old = datetime.now(UTC) - timedelta(hours=2)
+        blocklist.failed_attempts[PUBLIC_IP] = [old] * (
+            SecurityConfig.MAX_FAILED_ATTEMPTS - 1
+        )
+
+        blocklist.record_failed_attempt(PUBLIC_IP)
+
+        assert blocklist.is_blocked(PUBLIC_IP) is False
+        assert len(blocklist.failed_attempts[PUBLIC_IP]) == 1
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiter:
+    def test_burst_budget_is_enforced(self):
+        limiter = RateLimiter()
+
+        for i in range(SecurityConfig.RATE_LIMIT_BURST_SIZE):
+            allowed, _ = limiter.is_allowed(PUBLIC_IP)
+            assert allowed is True, f"request {i + 1} inside the burst must be allowed"
+
+        allowed, info = limiter.is_allowed(PUBLIC_IP)
+        assert allowed is False
+        assert info["reason"] == "burst_limit_exceeded"
+
+    def test_exhausting_one_client_does_not_affect_another(self):
+        limiter = RateLimiter()
+        for _ in range(SecurityConfig.RATE_LIMIT_BURST_SIZE + 1):
+            limiter.is_allowed(PUBLIC_IP)
+
+        allowed, _ = limiter.is_allowed("198.51.100.22")
+
+        assert allowed is True
+
+    def test_minute_window_is_enforced_independently_of_the_burst_budget(self):
+        limiter = RateLimiter()
+        now = datetime.now(UTC)
+        limiter.burst_tokens[PUBLIC_IP] = 999
+        limiter.requests[PUBLIC_IP].extend(
+            [now - timedelta(seconds=5)] * SecurityConfig.RATE_LIMIT_REQUESTS_PER_MINUTE
+        )
+
+        allowed, info = limiter.is_allowed(PUBLIC_IP)
+
+        assert allowed is False
+        assert info["reason"] == "minute_limit_exceeded"
+
+    def test_hour_window_is_enforced(self):
+        limiter = RateLimiter()
+        now = datetime.now(UTC)
+        limiter.burst_tokens[PUBLIC_IP] = 999
+        # Old enough to leave the minute window, recent enough to stay in the hour.
+        limiter.requests[PUBLIC_IP].extend(
+            [now - timedelta(minutes=30)] * SecurityConfig.RATE_LIMIT_REQUESTS_PER_HOUR
+        )
+
+        allowed, info = limiter.is_allowed(PUBLIC_IP)
+
+        assert allowed is False
+        assert info["reason"] == "hour_limit_exceeded"
+
+    def test_requests_older_than_one_hour_are_discarded(self):
+        limiter = RateLimiter()
+        stale = datetime.now(UTC) - timedelta(hours=2)
+        limiter.requests[PUBLIC_IP].extend(
+            [stale] * SecurityConfig.RATE_LIMIT_REQUESTS_PER_HOUR
+        )
+
+        allowed, info = limiter.is_allowed(PUBLIC_IP)
+
+        assert allowed is True
+        assert info["requests_last_hour"] == 1
+
+    def test_allowed_request_reports_and_consumes_one_burst_token(self):
+        limiter = RateLimiter()
+
+        allowed, info = limiter.is_allowed(PUBLIC_IP)
+
+        assert allowed is True
+        assert info["requests_last_minute"] == 1
+        assert info["burst_tokens"] == SecurityConfig.RATE_LIMIT_BURST_SIZE - 1
+
+
+# ---------------------------------------------------------------------------
+# RequestValidator
+# ---------------------------------------------------------------------------
+
+
+class TestRequestValidatorSize:
+    def test_oversized_content_length_is_rejected(self):
+        request = build_request(
+            headers={"content-length": str(SecurityConfig.MAX_REQUEST_SIZE + 1)}
+        )
+        assert RequestValidator().validate_request_size(request) is False
+
+    def test_content_length_at_the_limit_is_accepted(self):
+        request = build_request(
+            headers={"content-length": str(SecurityConfig.MAX_REQUEST_SIZE)}
+        )
+        assert RequestValidator().validate_request_size(request) is True
+
+    def test_non_numeric_content_length_is_rejected(self):
+        request = build_request(headers={"content-length": "not-a-number"})
+        assert RequestValidator().validate_request_size(request) is False
+
+    def test_missing_content_length_is_accepted(self):
+        assert RequestValidator().validate_request_size(build_request()) is True
+
+
+class TestRequestValidatorHeaders:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "<script>alert(1)</script>",
+            "javascript:alert(1)",
+            "' union select password from users --",
+            "../../etc/passwd",
+        ],
+    )
+    def test_malicious_value_in_a_custom_header_is_rejected(self, payload):
+        request = build_request(headers={"x-tenant-note": payload})
+
+        valid, error = RequestValidator().validate_headers(request)
+
+        assert valid is False
+        assert "x-tenant-note" in error
+
+    def test_browser_headers_are_exempt_from_pattern_matching(self):
+        # Real Chrome sends sec-ch-ua values full of characters that trip the
+        # command-injection patterns; blocking them would break every browser.
+        request = build_request(
+            headers={
+                "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+                "sec-ch-ua": '"Chromium";v="120", "Not:A-Brand";v="99"',
+                "accept": "text/html,application/xhtml+xml;q=0.9",
+            }
+        )
+
+        valid, error = RequestValidator().validate_headers(request)
+
+        assert valid is True
+        assert error is None
+
+    def test_oversized_headers_are_rejected(self):
+        request = build_request(
+            headers={"x-blob": "a" * (SecurityConfig.MAX_HEADER_SIZE + 10)}
+        )
+
+        valid, error = RequestValidator().validate_headers(request)
+
+        assert valid is False
+        assert error == "Headers too large"
+
+
+class TestRequestValidatorUrl:
+    @pytest.mark.parametrize(
+        ("path", "query"),
+        [
+            ("/api/v1/files/../../etc/passwd", ""),
+            ("/api/v1/search", "q=union+select+name+from+users"),
+            ("/api/v1/search", "q=<script>alert(1)</script>"),
+            ("/api/v1/proxy", "target=file:///etc/shadow"),
+            ("/api/v1/exec", "cmd=;%20rm"),
+        ],
+    )
+    def test_suspicious_url_is_rejected(self, path, query):
+        request = build_request(path=path, query=query)
+
+        valid, error = RequestValidator().validate_url(request)
+
+        assert valid is False
+        assert error is not None
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "id=1+union+select+password+from+users",  # form encoding of spaces
+            "id=1%20union%20select%20password%20from%20users",  # percent encoding
+            "name=x%27%3B%20drop%20table%20users%3B%20--",
+            "file=..%2F..%2Fetc%2Fpasswd",
+        ],
+    )
+    def test_encoded_payloads_do_not_bypass_pattern_matching(self, query):
+        # Every pattern that relies on \s is defeated by "+" or "%20" unless
+        # the validator scans the decoded query string too.
+        request = build_request(path="/api/v1/contracts", query=query)
+
+        valid, error = RequestValidator().validate_url(request)
+
+        assert valid is False, f"encoded payload slipped through: {query}"
+        assert error == "Suspicious pattern in URL"
+
+    def test_double_url_encoding_is_rejected_even_on_exempt_paths(self):
+        request = build_request(path="/docs", query="file=%252e%252e%252f")
+
+        valid, error = RequestValidator().validate_url(request)
+
+        assert valid is False
+        assert error == "Double URL encoding detected"
+
+    def test_overlong_url_is_rejected(self):
+        request = build_request(path="/api/v1/" + "a" * SecurityConfig.MAX_URL_LENGTH)
+
+        valid, error = RequestValidator().validate_url(request)
+
+        assert valid is False
+        assert error == "URL too long"
+
+    def test_exempt_path_skips_pattern_matching(self):
+        request = build_request(path="/openapi.json", query="q=union+select+1")
+
+        valid, error = RequestValidator().validate_url(request)
+
+        assert valid is True, "documentation paths are explicitly exempt"
+        assert error is None
+
+    def test_ordinary_url_is_accepted(self):
+        request = build_request(
+            path="/api/v1/investigations", query="page=2&order=created_at"
+        )
+
+        assert RequestValidator().validate_url(request) == (True, None)
+
+
+class TestRequestValidatorContentType:
+    @pytest.mark.parametrize(
+        "content_type",
+        ["application/xml", "text/html", "application/octet-stream"],
+    )
+    def test_unsupported_content_type_is_rejected(self, content_type):
+        request = build_request(headers={"content-type": content_type})
+        assert RequestValidator().validate_content_type(request) is False
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "application/json",
+            "application/json; charset=utf-8",
+            "APPLICATION/JSON",
+            "multipart/form-data; boundary=x",
+        ],
+    )
+    def test_supported_content_type_is_accepted(self, content_type):
+        request = build_request(headers={"content-type": content_type})
+        assert RequestValidator().validate_content_type(request) is True
+
+    def test_missing_content_type_is_accepted(self):
+        assert RequestValidator().validate_content_type(build_request()) is True
+
+
+class TestRequestValidatorBody:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            b'{"q": "drop table investigations"}',
+            b'{"q": "<script>fetch(1)</script>"}',
+            b'{"q": "1 or 1=1"}',
+            b'{"path": "../../etc/passwd"}',
+        ],
+    )
+    async def test_malicious_body_is_rejected(self, body):
+        valid, error = await RequestValidator().scan_request_body(body)
+
+        assert valid is False
+        assert error == "Suspicious pattern in request body"
+
+    async def test_clean_body_is_accepted(self):
+        body = b'{"query": "gastos com merenda escolar em 2024"}'
+
+        assert await RequestValidator().scan_request_body(body) == (True, None)
+
+    async def test_empty_body_is_accepted(self):
+        assert await RequestValidator().scan_request_body(b"") == (True, None)
+
+    async def test_invalid_utf8_bytes_do_not_raise(self):
+        valid, _ = await RequestValidator().scan_request_body(b"\xff\xfe\x00clean")
+
+        assert valid is True
+
+
+# ---------------------------------------------------------------------------
+# SecurityMiddleware.dispatch — the deny paths
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityMiddlewareDenies:
+    async def test_blocked_ip_gets_403_and_the_app_is_never_reached(
+        self, middleware, audit_spy
+    ):
+        for _ in range(SecurityConfig.MAX_FAILED_ATTEMPTS):
+            middleware.ip_blocklist.record_failed_attempt(PUBLIC_IP)
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(build_request(), call_next)
+
+        assert response.status_code == 403
+        call_next.assert_not_awaited()
+        audit_spy.assert_awaited()
+
+    async def test_rate_limited_request_gets_429_with_retry_headers(
+        self, middleware, audit_spy
+    ):
+        middleware.rate_limiter.burst_tokens[PUBLIC_IP] = 0
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(build_request(), call_next)
+
+        assert response.status_code == 429
+        assert response.headers["Retry-After"] == "60"
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        call_next.assert_not_awaited()
+
+    async def test_rate_limited_request_counts_as_a_failed_attempt(
+        self, middleware, audit_spy
+    ):
+        middleware.rate_limiter.burst_tokens[PUBLIC_IP] = 0
+
+        await middleware.dispatch(build_request(), AsyncMock())
+
+        assert middleware.ip_blocklist.get_failed_attempts_count(PUBLIC_IP) == 1
+
+    async def test_repeated_rate_limiting_eventually_blocks_the_ip(
+        self, middleware, audit_spy
+    ):
+        middleware.rate_limiter.burst_tokens[PUBLIC_IP] = 0
+
+        for _ in range(SecurityConfig.MAX_FAILED_ATTEMPTS):
+            await middleware.dispatch(build_request(), AsyncMock())
+
+        response = await middleware.dispatch(build_request(), AsyncMock())
+        assert response.status_code == 403, "rate-limit abuse must escalate to a block"
+
+    async def test_oversized_request_gets_413(self, middleware, audit_spy):
+        request = build_request(
+            headers={"content-length": str(SecurityConfig.MAX_REQUEST_SIZE + 1)}
+        )
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 413
+        call_next.assert_not_awaited()
+
+    async def test_suspicious_header_gets_400(self, middleware, audit_spy):
+        request = build_request(headers={"x-note": "<script>alert(1)</script>"})
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 400
+        call_next.assert_not_awaited()
+
+    async def test_sql_injection_in_query_string_gets_400(self, middleware, audit_spy):
+        request = build_request(
+            path="/api/v1/contracts", query="id=1+union+select+password+from+users"
+        )
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 400
+        call_next.assert_not_awaited()
+
+    async def test_unsupported_content_type_gets_415(self, middleware, audit_spy):
+        request = build_request(
+            method="POST", headers={"content-type": "application/xml"}
+        )
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 415
+        call_next.assert_not_awaited()
+
+    async def test_malicious_post_body_gets_400(self, middleware, audit_spy):
+        request = build_request(
+            path="/api/v1/chat",
+            method="POST",
+            headers={"content-type": "application/json"},
+            body=b'{"message": "ignore this; drop table users"}',
+        )
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 400
+        call_next.assert_not_awaited()
+
+    async def test_every_denial_is_audited(self, middleware, audit_spy):
+        request = build_request(path="/api/v1/x/../../etc/passwd")
+
+        await middleware.dispatch(request, AsyncMock())
+
+        assert audit_spy.await_count == 1
+        kwargs = audit_spy.await_args.kwargs
+        assert kwargs["success"] is False
+        assert kwargs["context"].ip_address == PUBLIC_IP
+
+
+class TestSecurityMiddlewareAllows:
+    async def test_legitimate_request_reaches_the_app_with_security_headers(
+        self, middleware, audit_spy
+    ):
+        request = build_request(
+            path="/api/v1/investigations",
+            method="POST",
+            headers={"content-type": "application/json"},
+            body=b'{"query": "contratos de merenda"}',
+        )
+
+        response = await middleware.dispatch(request, call_next_ok)
+
+        assert response.status_code == 200
+        for header, value in SecurityConfig.SECURITY_HEADERS.items():
+            assert response.headers[header] == value
+        assert "frame-ancestors 'none'" in response.headers["Content-Security-Policy"]
+        assert response.headers["X-RateLimit-Limit"] == str(
+            SecurityConfig.RATE_LIMIT_REQUESTS_PER_MINUTE
+        )
+        audit_spy.assert_not_awaited()
+
+    async def test_middleware_fails_open_when_a_security_check_crashes(
+        self, middleware, audit_spy
+    ):
+        # Availability is favoured over strictness: an internal error must not
+        # take the API down, but it must be audited as HIGH severity.
+        middleware.rate_limiter.is_allowed = lambda ip: (_ for _ in ()).throw(
+            RuntimeError("redis down")
+        )
+
+        response = await middleware.dispatch(build_request(), call_next_ok)
+
+        assert response.status_code == 200
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        audit_spy.assert_awaited_once()
+        assert "redis down" in audit_spy.await_args.kwargs["message"]
+
+
+class TestClientIpResolution:
+    async def test_first_x_forwarded_for_entry_wins(self, middleware):
+        request = build_request(
+            headers={"x-forwarded-for": "198.51.100.5, 10.0.0.1, 10.0.0.2"}
+        )
+
+        assert middleware._get_client_ip(request) == "198.51.100.5"
+
+    async def test_spoofed_x_forwarded_for_falls_back_to_x_real_ip(self, middleware):
+        request = build_request(
+            headers={
+                "x-forwarded-for": "not-an-ip",
+                "x-real-ip": "198.51.100.6",
+            }
+        )
+
+        assert middleware._get_client_ip(request) == "198.51.100.6"
+
+    async def test_falls_back_to_the_socket_peer(self, middleware):
+        request = build_request(headers={"x-forwarded-for": "<script>"})
+
+        assert middleware._get_client_ip(request) == PUBLIC_IP
+
+    async def test_returns_unknown_when_there_is_no_peer(self, middleware):
+        request = build_request(client_host=None)
+
+        assert middleware._get_client_ip(request) == "unknown"
+
+
+class TestSecurityHeaders:
+    def test_headers_are_added_to_an_arbitrary_response(self, middleware):
+        response = JSONResponse(content={"ok": True})
+
+        middleware._add_security_headers(response)
+
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert "Strict-Transport-Security" in response.headers
+        assert response.headers["Content-Security-Policy"].startswith(
+            "default-src 'self'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CSRF
+# ---------------------------------------------------------------------------
+
+
+class TestCSRFProtection:
+    def test_token_validates_for_the_session_that_generated_it(self):
+        csrf = CSRFProtection()
+        token = csrf.generate_token("session-abc")
+
+        assert csrf.validate_token(token, "session-abc") is True
+
+    def test_token_from_another_session_is_rejected(self):
+        csrf = CSRFProtection()
+        token = csrf.generate_token("session-victim")
+
+        assert csrf.validate_token(token, "session-attacker") is False
+
+    def test_tampered_signature_is_rejected(self):
+        csrf = CSRFProtection()
+        timestamp, signature = csrf.generate_token("session-abc").split(":", 1)
+        forged = f"{timestamp}:{'0' * len(signature)}"
+
+        assert csrf.validate_token(forged, "session-abc") is False
+
+    def test_tampered_timestamp_invalidates_the_signature(self):
+        csrf = CSRFProtection()
+        timestamp, signature = csrf.generate_token("session-abc").split(":", 1)
+        forged = f"{int(timestamp) + 1}:{signature}"
+
+        assert csrf.validate_token(forged, "session-abc") is False
+
+    def test_expired_token_is_rejected(self):
+        csrf = CSRFProtection()
+        token = csrf.generate_token("session-abc")
+
+        with patch("src.api.middleware.security.time.time") as fake_time:
+            fake_time.return_value = float(token.split(":")[0]) + 3601
+            assert csrf.validate_token(token, "session-abc", max_age=3600) is False
+
+    def test_token_within_max_age_is_accepted(self):
+        csrf = CSRFProtection()
+        token = csrf.generate_token("session-abc")
+
+        with patch("src.api.middleware.security.time.time") as fake_time:
+            fake_time.return_value = float(token.split(":")[0]) + 3500
+            assert csrf.validate_token(token, "session-abc", max_age=3600) is True
+
+    @pytest.mark.parametrize("token", ["", "garbage", "notanumber:sig", "::"])
+    def test_malformed_token_is_rejected_without_raising(self, token):
+        assert CSRFProtection().validate_token(token, "session-abc") is False
+
+    def test_two_sessions_never_share_a_signature(self):
+        csrf = CSRFProtection()
+
+        with patch("src.api.middleware.security.time.time", return_value=1_700_000_000):
+            token_a = csrf.generate_token("session-a")
+            token_b = csrf.generate_token("session-b")
+
+        assert token_a != token_b

--- a/tests/unit/middleware/test_security.py
+++ b/tests/unit/middleware/test_security.py
@@ -28,6 +28,7 @@ PUBLIC_IP = "203.0.113.7"  # TEST-NET-3, never whitelisted
 
 def build_request(
     path: str = "/api/v1/investigations",
+    *,
     method: str = "GET",
     headers: dict[str, str] | None = None,
     query: str = "",
@@ -90,9 +91,9 @@ class TestIPBlockList:
 
         for _ in range(SecurityConfig.MAX_FAILED_ATTEMPTS - 1):
             blocklist.record_failed_attempt(PUBLIC_IP)
-        assert blocklist.is_blocked(PUBLIC_IP) is False, (
-            "IP must stay allowed below the threshold"
-        )
+        assert (
+            blocklist.is_blocked(PUBLIC_IP) is False
+        ), "IP must stay allowed below the threshold"
 
         blocklist.record_failed_attempt(PUBLIC_IP)
         assert blocklist.is_blocked(PUBLIC_IP) is True
@@ -109,9 +110,9 @@ class TestIPBlockList:
 
         assert blocklist.is_whitelisted(ip) is True
         assert blocklist.is_blocked(ip) is False
-        assert blocklist.failed_attempts[ip] == [], (
-            "whitelisted IPs must not accumulate failed attempts"
-        )
+        assert (
+            blocklist.failed_attempts[ip] == []
+        ), "whitelisted IPs must not accumulate failed attempts"
 
     def test_block_expires_after_the_configured_duration(self):
         blocklist = IPBlockList()

--- a/tests/unit/middleware/test_security.py
+++ b/tests/unit/middleware/test_security.py
@@ -410,20 +410,24 @@ class TestRequestValidatorBody:
             b'{"path": "../../etc/passwd"}',
         ],
     )
+    @pytest.mark.asyncio
     async def test_malicious_body_is_rejected(self, body):
         valid, error = await RequestValidator().scan_request_body(body)
 
         assert valid is False
         assert error == "Suspicious pattern in request body"
 
+    @pytest.mark.asyncio
     async def test_clean_body_is_accepted(self):
         body = b'{"query": "gastos com merenda escolar em 2024"}'
 
         assert await RequestValidator().scan_request_body(body) == (True, None)
 
+    @pytest.mark.asyncio
     async def test_empty_body_is_accepted(self):
         assert await RequestValidator().scan_request_body(b"") == (True, None)
 
+    @pytest.mark.asyncio
     async def test_invalid_utf8_bytes_do_not_raise(self):
         valid, _ = await RequestValidator().scan_request_body(b"\xff\xfe\x00clean")
 
@@ -436,6 +440,7 @@ class TestRequestValidatorBody:
 
 
 class TestSecurityMiddlewareDenies:
+    @pytest.mark.asyncio
     async def test_blocked_ip_gets_403_and_the_app_is_never_reached(
         self, middleware, audit_spy
     ):
@@ -449,6 +454,7 @@ class TestSecurityMiddlewareDenies:
         call_next.assert_not_awaited()
         audit_spy.assert_awaited()
 
+    @pytest.mark.asyncio
     async def test_rate_limited_request_gets_429_with_retry_headers(
         self, middleware, audit_spy
     ):
@@ -462,6 +468,7 @@ class TestSecurityMiddlewareDenies:
         assert response.headers["X-RateLimit-Remaining"] == "0"
         call_next.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_rate_limited_request_counts_as_a_failed_attempt(
         self, middleware, audit_spy
     ):
@@ -471,6 +478,7 @@ class TestSecurityMiddlewareDenies:
 
         assert middleware.ip_blocklist.get_failed_attempts_count(PUBLIC_IP) == 1
 
+    @pytest.mark.asyncio
     async def test_repeated_rate_limiting_eventually_blocks_the_ip(
         self, middleware, audit_spy
     ):
@@ -482,6 +490,7 @@ class TestSecurityMiddlewareDenies:
         response = await middleware.dispatch(build_request(), AsyncMock())
         assert response.status_code == 403, "rate-limit abuse must escalate to a block"
 
+    @pytest.mark.asyncio
     async def test_oversized_request_gets_413(self, middleware, audit_spy):
         request = build_request(
             headers={"content-length": str(SecurityConfig.MAX_REQUEST_SIZE + 1)}
@@ -493,6 +502,7 @@ class TestSecurityMiddlewareDenies:
         assert response.status_code == 413
         call_next.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_suspicious_header_gets_400(self, middleware, audit_spy):
         request = build_request(headers={"x-note": "<script>alert(1)</script>"})
         call_next = AsyncMock()
@@ -502,6 +512,7 @@ class TestSecurityMiddlewareDenies:
         assert response.status_code == 400
         call_next.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_sql_injection_in_query_string_gets_400(self, middleware, audit_spy):
         request = build_request(
             path="/api/v1/contracts", query="id=1+union+select+password+from+users"
@@ -513,6 +524,7 @@ class TestSecurityMiddlewareDenies:
         assert response.status_code == 400
         call_next.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_unsupported_content_type_gets_415(self, middleware, audit_spy):
         request = build_request(
             method="POST", headers={"content-type": "application/xml"}
@@ -524,6 +536,7 @@ class TestSecurityMiddlewareDenies:
         assert response.status_code == 415
         call_next.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_malicious_post_body_gets_400(self, middleware, audit_spy):
         request = build_request(
             path="/api/v1/chat",
@@ -538,6 +551,7 @@ class TestSecurityMiddlewareDenies:
         assert response.status_code == 400
         call_next.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_every_denial_is_audited(self, middleware, audit_spy):
         request = build_request(path="/api/v1/x/../../etc/passwd")
 
@@ -550,6 +564,7 @@ class TestSecurityMiddlewareDenies:
 
 
 class TestSecurityMiddlewareAllows:
+    @pytest.mark.asyncio
     async def test_legitimate_request_reaches_the_app_with_security_headers(
         self, middleware, audit_spy
     ):
@@ -571,6 +586,7 @@ class TestSecurityMiddlewareAllows:
         )
         audit_spy.assert_not_awaited()
 
+    @pytest.mark.asyncio
     async def test_middleware_fails_open_when_a_security_check_crashes(
         self, middleware, audit_spy
     ):
@@ -589,6 +605,7 @@ class TestSecurityMiddlewareAllows:
 
 
 class TestClientIpResolution:
+    @pytest.mark.asyncio
     async def test_first_x_forwarded_for_entry_wins(self, middleware):
         request = build_request(
             headers={"x-forwarded-for": "198.51.100.5, 10.0.0.1, 10.0.0.2"}
@@ -596,6 +613,7 @@ class TestClientIpResolution:
 
         assert middleware._get_client_ip(request) == "198.51.100.5"
 
+    @pytest.mark.asyncio
     async def test_spoofed_x_forwarded_for_falls_back_to_x_real_ip(self, middleware):
         request = build_request(
             headers={
@@ -606,11 +624,13 @@ class TestClientIpResolution:
 
         assert middleware._get_client_ip(request) == "198.51.100.6"
 
+    @pytest.mark.asyncio
     async def test_falls_back_to_the_socket_peer(self, middleware):
         request = build_request(headers={"x-forwarded-for": "<script>"})
 
         assert middleware._get_client_ip(request) == PUBLIC_IP
 
+    @pytest.mark.asyncio
     async def test_returns_unknown_when_there_is_no_peer(self, middleware):
         request = build_request(client_host=None)
 


### PR DESCRIPTION
Two modules that were at 0% coverage: `src/api/middleware/security.py` (254 statements) and `src/llm/providers.py` (351 statements). Writing the tests turned up three defects, all fixed here.

## Coverage

| Module | Before | After |
|---|---|---|
| `src/api/middleware/security.py` | 0.00% (never imported by any test) | **96.22%** |
| `src/llm/providers.py` | 0.00% (never imported by any test) | **89.14%** |

151 new tests, all green in 3s.

## Defects found and fixed

**1. URL-encoded payloads bypassed the request scanner** (`security.py`)

The suspicious-pattern list was matched against the *raw* query string, where a space is `+` or `%20`. Every pattern relying on `\s` — `union select`, `drop table`, `insert into`, `delete from`, `update ... set` — therefore never fired on a real request:

```
?id=1+union+select+password+from+users   -> passed the scanner
?id=1 union select password from users   -> blocked
```

The validator now also scans the `unquote_plus`-decoded path and query.

**2. The LLM fallback chain collapsed when the primary was also a fallback** (`providers.py`)

The loop ended on `provider == providers_to_try[-1]`, a value comparison on a `str` enum. The default fallback list is `[together, huggingface, maritaca]` and Maritaca is the configured primary in production, so the first element equalled the last. A Maritaca outage broke out of the loop on the first iteration and raised "All LLM providers failed" **without ever contacting a fallback**. `_build_provider_chain` now de-duplicates the chain and the loop ends on the index.

**3. `LLMRateLimitError` was downgraded to a generic `LLMError`** (`providers.py`)

`_handle_error_response` classified a 429 correctly, but the broad `except Exception` around it re-raised it as `LLMError("Unexpected error: Rate limit exceeded")`. Callers could not distinguish a quota exhaustion worth retrying from a permanent failure. `LLMError` subclasses are now re-raised unchanged, in both the streaming and non-streaming paths.

## What the tests cover

`tests/unit/middleware/test_security.py` (81 tests) — deliberately weighted towards the deny paths: blocked IP (403, and the app is never reached), exhausted rate limit (429 with `Retry-After`, and the abuse escalating into a block), oversized body (413), suspicious header/URL/body (400), unsupported content type (415). Also the IP whitelist, block expiry, the three rate-limit windows, client-IP resolution through spoofed `X-Forwarded-For`, the documented fail-open behaviour when a check crashes, and CSRF token forgery, cross-session reuse and expiry.

`tests/unit/llm/test_providers.py` (70 tests) — every fallback test asserts *which* providers were contacted, not just the value returned, so a chain that silently stops early fails. Plus retry and backoff on 429/5xx/timeout, pool degradation to the direct client, SSE chunk parsing and `[DONE]` handling, payload shaping for each provider, and the dummy-key path taken when `MARITACA_API_KEY` is unset.

## Verification

Each assertion was checked with a positive control — production code was broken on purpose and the intended tests went red, then the break was reverted:

| Induced break | Red tests |
|---|---|
| `IPBlockList.is_blocked` always `False` | 4 |
| `RateLimiter.is_allowed` always allows | 8 |
| `CSRFProtection.validate_token` always `True` | 8 |
| Revert the chain de-duplication | 1 (the Maritaca-primary case) |
| Drop the `except LLMError: raise` | 2 (both rate-limit type tests) |
| Chain stops after the primary | 8 |

Full `tests/unit` run: 2347 passed, 6 failed — all six also fail on `origin/main` (`test_drummond_expanded`, `test_notification_service`, `test_maritaca_client::test_chat_completion_rate_limit`) or are order-flaky (`test_dandara.py` fails *different* tests on a clean tree; it reaches real transparency APIs).

## Notes for the reviewer

- `SecurityMiddleware` is currently **commented out** in `app.py:271` pending a whitelist configuration, so fix 1 has no production effect today — it matters the moment the middleware is re-enabled.
- `providers.py` has **no Anthropic provider**; the chain here is groq / together / huggingface / maritaca. The Maritaca -> Anthropic fallback described in `CLAUDE.md` lives elsewhere (`routes/chat.py`). A test pins `create_llm_manager("anthropic")` raising `ValueError` so the gap is explicit.
- `pytest --cov=path/to/file.py` silently collects nothing with coverage 7.16 ("module was never imported"); use the directory form (`--cov=src/llm`) or the numbers will read 0% forever.

https://claude.ai/code/session_015bgSy5JxseiACEYDL9Wk4z