### PR TITLE
refactor(utils): type the organization mapping table and its readers

### DIFF
--- a/src/utils/organization_mapping.py
+++ b/src/utils/organization_mapping.py
@@ -4,12 +4,55 @@ Enables natural language queries like "Ministério da Saúde" -> code "26000"
 """
 
 import re
+from typing import TypedDict
 
 from unidecode import unidecode
 
+
+class OrganizationRecord(TypedDict):
+    """A single federal organization as stored in FEDERAL_ORGANIZATIONS.
+
+    Attributes:
+        official_name: Name as published by the Portal da Transparência.
+        aliases: Spellings accepted in natural language queries, including
+            unaccented and abbreviated forms.
+    """
+
+    official_name: str
+    aliases: list[str]
+
+
+class OrganizationMatch(TypedDict):
+    """One organization recognised inside a free-text query.
+
+    Attributes:
+        code: SIAFI organization code (e.g. ``"26000"``).
+        name: Official organization name.
+        matched_text: Normalized alias that triggered the match.
+    """
+
+    code: str
+    name: str
+    matched_text: str
+
+
+class OrganizationListing(TypedDict):
+    """An organization as returned by :meth:`OrganizationMapper.list_all_organizations`.
+
+    Attributes:
+        code: SIAFI organization code.
+        name: Official organization name.
+        aliases: Every accepted spelling for this organization.
+    """
+
+    code: str
+    name: str
+    aliases: list[str]
+
+
 # Complete mapping of Brazilian federal government organizations
 # Source: Portal da Transparência Federal API
-FEDERAL_ORGANIZATIONS = {
+FEDERAL_ORGANIZATIONS: dict[str, OrganizationRecord] = {
     # Ministérios e Órgãos Superiores
     "20000": {
         "official_name": "Presidência da República",
@@ -206,14 +249,15 @@ FEDERAL_ORGANIZATIONS = {
 class OrganizationMapper:
     """Maps organization names to official codes for API queries"""
 
-    def __init__(self):
-        self.orgs = FEDERAL_ORGANIZATIONS
+    def __init__(self) -> None:
+        """Load the organization table and build the alias lookup index."""
+        self.orgs: dict[str, OrganizationRecord] = FEDERAL_ORGANIZATIONS
         # Build reverse index for fast lookup
         self._build_reverse_index()
 
-    def _build_reverse_index(self):
+    def _build_reverse_index(self) -> None:
         """Build reverse index from aliases to codes"""
-        self.alias_to_code = {}
+        self.alias_to_code: dict[str, str] = {}
 
         for code, org_data in self.orgs.items():
             # Add official name
@@ -274,7 +318,7 @@ class OrganizationMapper:
 
         return None
 
-    def extract_organizations_from_text(self, text: str) -> list[dict]:
+    def extract_organizations_from_text(self, text: str) -> list[OrganizationMatch]:
         """
         Extract all organization mentions from text.
 
@@ -297,7 +341,7 @@ class OrganizationMapper:
         if not text:
             return []
 
-        found = []
+        found: list[OrganizationMatch] = []
         normalized_text = self._normalize(text)
 
         # Search for each alias in the text
@@ -315,11 +359,11 @@ class OrganizationMapper:
 
         return found
 
-    def get_organization_info(self, code: str) -> dict | None:
+    def get_organization_info(self, code: str) -> OrganizationRecord | None:
         """Get full organization information by code"""
         return self.orgs.get(code)
 
-    def list_all_organizations(self) -> list[dict]:
+    def list_all_organizations(self) -> list[OrganizationListing]:
         """List all available organizations"""
         return [
             {
@@ -332,7 +376,7 @@ class OrganizationMapper:
 
 
 # Global singleton instance
-_mapper_instance = None
+_mapper_instance: OrganizationMapper | None = None
 
 
 def get_organization_mapper() -> OrganizationMapper:


### PR DESCRIPTION
Closes #8

## Module chosen

`src/utils/organization_mapping.py`. The other two modules in `src/utils/` were checked first:

| module | `mypy --strict` before |
|---|---|
| `date_range_defaults.py` | **0 errors** — already fully annotated, nothing to do |
| `organization_mapping.py` | 9 errors ← chosen |
| `cors_validator.py` | 9 errors — see "Left open" |

## What changed

Three `TypedDict`s name the shapes the module was already returning, so nothing is widened to `Any`:

- `OrganizationRecord` — an entry of `FEDERAL_ORGANIZATIONS`
- `OrganizationMatch` — one hit from `extract_organizations_from_text`
- `OrganizationListing` — one row of `list_all_organizations`

`FEDERAL_ORGANIZATIONS` is annotated against the first. Without it the table inferred as `dict[str, dict[str, str | list[str]]]`, which made `self._normalize(org_data["official_name"])` type-check as `Sequence[str]` and handed every caller of the getters an unparameterised `dict`. Typing the table at the source is what let the three `-> list[dict]` / `-> dict | None` signatures become concrete with no cast at any call site.

Also annotated: `__init__` and `_build_reverse_index` returns, the `orgs` / `alias_to_code` attributes, the `found` accumulator, and the `_mapper_instance` singleton.

## Verification

`mypy --strict` on the module, 9 errors → 0:

```
$ mypy --strict --ignore-missing-imports src/utils/organization_mapping.py
Success: no issues found in 1 source file
```

Formatters and linter clean:

```
$ black --check src/utils/organization_mapping.py
1 file would be left unchanged.
$ isort --check-only src/utils/organization_mapping.py     # silent
$ ruff check src/utils/organization_mapping.py
All checks passed!
```

Annotation-only, so behaviour was diffed against `origin/main` by loading both versions side by side in one interpreter:

```
find_organization_code igual: True ['26000', '26000', '25000', None, '20000', '62000', None]
extract igual: True
list_all igual: True
get_info igual: True
```

Unit suite (2433 tests):

```
3 failed, 2377 passed, 53 skipped, 358 warnings in 121.54s
```

The 3 failures are all in `tests/unit/agents/test_drummond_expanded.py` and reproduce identically on unmodified `origin/main` — they are pre-existing and unrelated to this change.

The two consumers of the module were measured before and after: `chat_service.py` stays at 9 mypy errors, `chat_investigative_service.py` goes 4 → 3.

## Left open

`src/utils/cors_validator.py` has its own 9 errors, and two of them are a real defect rather than a missing annotation: lines 83 and 170 annotate `dict[str, any]` with the **builtin `any` function** instead of `typing.Any`. mypy rejects it as `Function "builtins.any" is not valid as a type`, and the four `Unsupported target for indexed assignment ("Collection[str]")` errors below it are fallout from that one typo. Not touched here to keep this PR to a single module as the issue asks.